### PR TITLE
 Zephyr high-level and functional requirements: migrate to RELATIONS and auto-generate UIDs 

### DIFF
--- a/docs/zephyr_01_high_level_requirements.sdoc
+++ b/docs/zephyr_01_high_level_requirements.sdoc
@@ -1,5 +1,6 @@
 [DOCUMENT]
 TITLE: Zephyr High Level Requirements
+REQ_PREFIX: ZEP-
 
 [GRAMMAR]
 ELEMENTS:
@@ -97,6 +98,7 @@ TBD: The requirement needs refinement.
 <<<
 
 [REQUIREMENT]
+UID: ZEP-35
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Utilities Library - Data Structures
@@ -117,6 +119,7 @@ Clarification: There are many files. Linked list, ring buffer, ...). This is an 
 <<<
 
 [REQUIREMENT]
+UID: ZEP-36
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Device Driver API
@@ -135,6 +138,7 @@ TBD: Title seems to need refinement. Also, this requirement's user story seems t
 <<<
 
 [REQUIREMENT]
+UID: ZEP-37
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Exception and Error Handling
@@ -150,6 +154,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-38
 STATUS: Draft
 TYPE: High Level
 COMPONENT: File Systems
@@ -165,6 +170,7 @@ TBD: 2022/4/13 - ok - p? - depends on set of expectations
 <<<
 
 [REQUIREMENT]
+UID: ZEP-39
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Interrupts
@@ -180,6 +186,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-40
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Logging
@@ -198,6 +205,7 @@ Nicole: TBD: we need to have logging in the safety scope?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-41
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Memory Management
@@ -213,6 +221,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-42
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Power Management
@@ -228,6 +237,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-43
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Thread Communication
@@ -243,6 +253,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-44
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Thread Mapping (should it just be scheduling)

--- a/docs/zephyr_01_high_level_requirements.sdoc
+++ b/docs/zephyr_01_high_level_requirements.sdoc
@@ -17,9 +17,6 @@ ELEMENTS:
   - TITLE: COMPONENT
     TYPE: String
     REQUIRED: False
-  - TITLE: REFS
-    TYPE: Reference(ParentReqReference)
-    REQUIRED: False
   - TITLE: TITLE
     TYPE: String
     REQUIRED: False
@@ -35,6 +32,8 @@ ELEMENTS:
   - TITLE: REVIEW_COMMENT
     TYPE: String
     REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
 
 [REQUIREMENT]
 UID: ZEP-1
@@ -57,9 +56,6 @@ UID: ZEP-3
 STATUS: Draft
 TYPE: High Level
 COMPONENT: Hardware Architecture Interface
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-1
 TITLE: Support multiprocessor management
 STATEMENT: >>>
 Zephyr shall support symmetric multiprocessing on multiple cores.
@@ -73,6 +69,9 @@ TBD: Still need to articulate the capabilities explicitly.
 REVIEW_COMMENT: >>>
 From the Docs: No special application code needs to be written to take advantage of this feature
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-1
 
 [REQUIREMENT]
 UID: ZEP-2

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1,5 +1,6 @@
 [DOCUMENT]
 TITLE: Zephyr Functional Requirements
+REQ_PREFIX: ZEP-
 
 [GRAMMAR]
 ELEMENTS:
@@ -343,6 +344,7 @@ RELATIONS:
 TITLE: Device Driver API
 
 [REQUIREMENT]
+UID: ZEP-45
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Device Driver API
@@ -367,6 +369,7 @@ Clarification: Abstract API drivers, UART. Set of files asociated with that. Inc
 <<<
 
 [REQUIREMENT]
+UID: ZEP-46
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Device Driver API
@@ -392,6 +395,7 @@ NP: Now I think system means HW platform.
 TITLE: Exception and Error Handling
 
 [REQUIREMENT]
+UID: ZEP-47
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Exception and Error Handling
@@ -407,6 +411,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-48
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Exception and Error Handling
@@ -422,6 +427,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-49
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Exception and Error Handling
@@ -431,6 +437,7 @@ Zephyr shall provide an interface to assign a specific handler with an exception
 <<<
 
 [REQUIREMENT]
+UID: ZEP-50
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Exception and Error Handling
@@ -445,6 +452,7 @@ Zephyr shall provide an interface to assign a specific handler for a fatal error
 TITLE: File System
 
 [REQUIREMENT]
+UID: ZEP-51
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -460,6 +468,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-52
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -476,6 +485,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-53
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -491,6 +501,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-54
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -506,6 +517,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-55
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -521,6 +533,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-56
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -533,6 +546,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-57
 STATUS: Draft
 TYPE: Functional
 COMPONENT: File System
@@ -553,6 +567,7 @@ DISCUSSION_DATE: >>>
 TITLE: Interrupts
 
 [REQUIREMENT]
+UID: ZEP-58
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Interrupts
@@ -568,6 +583,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-59
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Interrupts
@@ -583,6 +599,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-60
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Interrupts
@@ -598,6 +615,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-61
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Interrupts
@@ -613,6 +631,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-62
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Interrupts
@@ -633,6 +652,7 @@ DISCUSSION_DATE: >>>
 TITLE: Logging
 
 [REQUIREMENT]
+UID: ZEP-63
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -648,6 +668,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-64
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -663,6 +684,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-65
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -681,6 +703,7 @@ Question: formatting in which way? length, color, tags, etc?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-66
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -699,6 +722,7 @@ Question: Filtering during runtime or a kconfig option to initially set the filt
 <<<
 
 [REQUIREMENT]
+UID: ZEP-67
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -717,6 +741,7 @@ Question: What kind of backends shall be supported? More than one at a time?   W
 <<<
 
 [REQUIREMENT]
+UID: ZEP-68
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Logging
@@ -737,6 +762,7 @@ DISCUSSION_DATE: >>>
 TITLE: Memory protection
 
 [REQUIREMENT]
+UID: ZEP-69
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -755,6 +781,7 @@ Functional it is memory management, but it also strongly relates to the architec
 <<<
 
 [REQUIREMENT]
+UID: ZEP-70
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -773,6 +800,7 @@ What are the conditions to a user thread to get access to a kernel object?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-71
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -788,6 +816,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-72
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -806,6 +835,7 @@ What is an "unimplemented system call"? An empty system call function? Can I cal
 <<<
 
 [REQUIREMENT]
+UID: ZEP-73
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -821,6 +851,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-74
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -838,6 +869,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-75
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -853,6 +885,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-76
 STATUS: Draft
 TYPE: Functional
 COMPONENT: TBD: Memory Protection --> Thread
@@ -868,6 +901,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-77
 STATUS: Draft
 TYPE: Functional
 COMPONENT: TBD: Memory Protection --> Thread
@@ -883,6 +917,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-78
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -898,6 +933,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-79
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -916,6 +952,7 @@ Need for handlers and callbacks outside of thread.   Need to be able to answer "
 <<<
 
 [REQUIREMENT]
+UID: ZEP-80
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -934,6 +971,7 @@ RS: IMHO should be configurable due the to performance penalty introduced with i
 <<<
 
 [REQUIREMENT]
+UID: ZEP-81
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -952,6 +990,7 @@ What does "policy" mean in this context? Does this mean to choose between differ
 <<<
 
 [REQUIREMENT]
+UID: ZEP-82
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -970,6 +1009,7 @@ I do not understand that. What kind of helper functions? Kind of plausibility ch
 <<<
 
 [REQUIREMENT]
+UID: ZEP-83
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -993,6 +1033,7 @@ Is this a helper function like mentioned in ZEP133? What does C string mean here
 <<<
 
 [REQUIREMENT]
+UID: ZEP-84
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -1016,6 +1057,7 @@ Does this mean that the user mode threads are monitored wrt to their usage of ke
 <<<
 
 [REQUIREMENT]
+UID: ZEP-85
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -1034,6 +1076,7 @@ What is the difference to ZEP 011?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-86
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Protection
@@ -1057,6 +1100,7 @@ What is the difference to ZEP 136? Read & Write, while ZEP136 is just read?
 TITLE: Memory Objects
 
 [REQUIREMENT]
+UID: ZEP-87
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Objects
@@ -1075,6 +1119,7 @@ Is dynamic memory allocation only allowed in memory pool objects?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-88
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Memory Objects
@@ -1095,6 +1140,7 @@ DISCUSSION_DATE: >>>
 TITLE: Data Passing
 
 [REQUIREMENT]
+UID: ZEP-89
 STATUS: Draft
 TYPE: Functional
 COMPONENT: see: https://docs.zephyrproject.org/latest/reference/kernel/index.html - Data Passing
@@ -1110,6 +1156,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-90
 STATUS: Draft
 TYPE: Functional
 COMPONENT: see: https://docs.zephyrproject.org/latest/reference/kernel/index.html - Data Passing
@@ -1130,6 +1177,7 @@ DISCUSSION_DATE: >>>
 TITLE: Mutex
 
 [REQUIREMENT]
+UID: ZEP-91
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Mutex
@@ -1156,6 +1204,7 @@ Concern over phrase recursive.  What is it MUTEXing? Memory Management?
 TITLE: Power Management
 
 [REQUIREMENT]
+UID: ZEP-92
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Power Management
@@ -1173,6 +1222,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-93
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Power Management
@@ -1185,6 +1235,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-94
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Power Management
@@ -1202,6 +1253,7 @@ DISCUSSION_DATE: >>>
 TITLE: Thread Communication
 
 [REQUIREMENT]
+UID: ZEP-95
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1219,6 +1271,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-96
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1234,6 +1287,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-97
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1249,6 +1303,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-98
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1267,6 +1322,7 @@ stack of what?
 <<<
 
 [REQUIREMENT]
+UID: ZEP-99
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1281,6 +1337,7 @@ Architectural & interface REQ
 <<<
 
 [REQUIREMENT]
+UID: ZEP-100
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1293,6 +1350,7 @@ As a Zephyr OS user I want my thread to wait for one of several defined events t
 <<<
 
 [REQUIREMENT]
+UID: ZEP-101
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1308,6 +1366,7 @@ DISCUSSION_DATE: >>>
 <<<
 
 [REQUIREMENT]
+UID: ZEP-102
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1325,6 +1384,7 @@ This might be too implementation specific. Better: Zephyr shall allow threads an
 <<<
 
 [REQUIREMENT]
+UID: ZEP-103
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Communication
@@ -1342,6 +1402,7 @@ As a Zephyr OS user I want to... ???
 TITLE: Thread Scheduling
 
 [REQUIREMENT]
+UID: ZEP-104
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Mapping (should it just be scheduling) -
@@ -1356,6 +1417,7 @@ Is see it as an internal hidden from the user.
 <<<
 
 [REQUIREMENT]
+UID: ZEP-105
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Mapping (should it just be scheduling)
@@ -1371,6 +1433,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-106
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Mapping (should it just be scheduling?)
@@ -1399,6 +1462,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-107
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1411,6 +1475,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-108
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1423,6 +1488,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-109
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1435,6 +1501,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-110
 STATUS: Draft
 TITLE: Resuming a suspended thread after a timeout
 STATEMENT: >>>
@@ -1445,6 +1512,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-111
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1457,6 +1525,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-112
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1472,6 +1541,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-113
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1487,6 +1557,7 @@ Does this make sense in the safety scope? It is conflicting with ZEP151.
 <<<
 
 [REQUIREMENT]
+UID: ZEP-114
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1499,6 +1570,7 @@ As a Zephyr OS user, I want to be able to schedule threads by earliest deadine f
 <<<
 
 [REQUIREMENT]
+UID: ZEP-115
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1533,6 +1605,7 @@ Where do we put this,  thread, scheduling or???
 <<<
 
 [REQUIREMENT]
+UID: ZEP-116
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1551,6 +1624,7 @@ Zephyr shall allow priorising threads
 <<<
 
 [REQUIREMENT]
+UID: ZEP-117
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1566,6 +1640,7 @@ Need to break this down to atomic level
 <<<
 
 [REQUIREMENT]
+UID: ZEP-118
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1581,6 +1656,7 @@ Need to break this down to atomic level
 <<<
 
 [REQUIREMENT]
+UID: ZEP-119
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Thread Scheduling
@@ -1604,6 +1680,7 @@ what does traditional mean here?   Round robin?
 TITLE: Threads
 
 [REQUIREMENT]
+UID: ZEP-120
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Threads
@@ -1648,6 +1725,7 @@ pf-ok
 <<<
 
 [REQUIREMENT]
+UID: ZEP-121
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Threads

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -17,9 +17,6 @@ ELEMENTS:
   - TITLE: COMPONENT
     TYPE: String
     REQUIRED: False
-  - TITLE: REFS
-    TYPE: Reference(ParentReqReference)
-    REQUIRED: False
   - TITLE: TITLE
     TYPE: String
     REQUIRED: False
@@ -35,6 +32,8 @@ ELEMENTS:
   - TITLE: REVIEW_COMMENT
     TYPE: String
     REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
 
 [SECTION]
 TITLE: Hardware Architecture Interface
@@ -44,9 +43,6 @@ UID: ZEP-8
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Hardware Architecture Interface
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-1
 TITLE: Atomic Operations
 STATEMENT: >>>
 Zephyr shall provide an interface functionality to access memory while ensuring mutual exclusion. Note: Implementation by atomic variables and accessing them by APIs.
@@ -57,15 +53,15 @@ As a Zephyr OS user I want to read from or write into a memory areas without bei
 DISCUSSION_DATE: >>>
 2022/3/30 - ok - pq
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-1
 
 [REQUIREMENT]
 UID: ZEP-9
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Hardware Architecture Interface
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-1
 TITLE: Thread Context Switching
 STATEMENT: >>>
 Zephyr shall provide a mechanism for context switching between threads.
@@ -76,15 +72,15 @@ As a Zephyr OS user I want to execute code concurrently in one or more threads a
 DISCUSSION_DATE: >>>
 2022/3/30 - ok - pf
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-1
 
 [REQUIREMENT]
 UID: ZEP-10
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Hardware Architecture Interface
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-1
 TITLE: Software Exceptions
 STATEMENT: >>>
 Zephyr shall provide an interface to implement software exceptions.
@@ -95,15 +91,15 @@ As a Zephyr OS user I want to catch any software exception and handle it accordi
 DISCUSSION_DATE: >>>
 2022/3/30 - ok - pq
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-1
 
 [REQUIREMENT]
 UID: ZEP-11
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Hardware Architecture Interface
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-1
 TITLE: Processor Mode Support
 STATEMENT: >>>
 Zephyr shall provide an interface for managing processor modes.
@@ -120,6 +116,9 @@ What is lifecycle - power on, standby, power off?  or ????
 
 Clarification: Starting and Stopping, and putting it into Stand-By Mode (whatever the processor supports)
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-1
 
 [/SECTION]
 
@@ -131,9 +130,6 @@ UID: ZEP-12
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Formatted output
 STATEMENT: >>>
 Zephyr shall support formatted output.
@@ -144,15 +140,15 @@ As a Zephyr OS user, I want to be able to printf with various output formats.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-13
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Floating Point Math Support
 STATEMENT: >>>
 Zephyr shall support floating point math libraries for processors where floating point is available.
@@ -163,15 +159,15 @@ As a Zephyr OS user, I want to be able to calculate with floating point numbers.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-14
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Boolean Primitives Support
 STATEMENT: >>>
 Zephyr shall support boolean primitives.
@@ -182,15 +178,15 @@ As a Zephyr OS user, I want to be able to work with boolean values and logic.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-15
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Standard Unix time interface
 STATEMENT: >>>
 Zephyr shall support the standard unix time interface.
@@ -201,15 +197,15 @@ As a Zephyr User, I want to be able to use system time.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-16
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Strings support
 STATEMENT: >>>
 Zephyr shall support an interface to manage strings.
@@ -220,15 +216,15 @@ As a Zephyr OS user, I want to be able to manipulate text strings.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-17
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Moving/copying regions of memory
 STATEMENT: >>>
 Zephyr shall support an interface to move contents between regions of memory.
@@ -239,15 +235,15 @@ As a Zephyr OS user, I want to copy the memory contents to different addresses.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-18
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: I/O based interface
 STATEMENT: >>>
 Zephyr shall support a file i/O based interface for driver communication.
@@ -261,15 +257,15 @@ DISCUSSION_DATE: >>>
 REVIEW_COMMENT: >>>
 A wrong C header seems to be included: stdint.h does not have to do with I/O.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-19
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: C99 integer types
 STATEMENT: >>>
 Zephyr shall support standard C99 integer types.
@@ -280,15 +276,15 @@ As a Zephyr OS user, I want to be able to calculate with C99 Integers.
 DISCUSSION_DATE: >>>
 20221122.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-20
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Standard System Error Numbers (IEEE Std 1003.1-2017)
 STATEMENT: >>>
 Zephyr shall support standard system error numbers as defined by IEEE Std 1003.1-2017.
@@ -299,15 +295,15 @@ As a Zephyr OS user, I want to be able to use IEE Std 1003.1-2017 Error Numbers 
 DISCUSSION_DATE: >>>
 20221129.0
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-21
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Document set of Zephyr OS required C librariy functions in Safety Manual
 STATEMENT: >>>
 The set of C Library functions required by Zephyr needs to be documented in the Zephyr Safety Manual.
@@ -318,15 +314,15 @@ As a Zephyr user, I want to know which C library functions are being called by t
 DISCUSSION_DATE: >>>
 TBD: Revisit after subset defined.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [REQUIREMENT]
 UID: ZEP-22
 STATUS: Draft
 TYPE: Functional
 COMPONENT: C Library
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-2
 TITLE: Support external C libraries documentation in Zephyr Safety Manual
 STATEMENT: >>>
 The Zephyr Safety Manual needs to specify how to configure the support of external C Libraries.
@@ -337,6 +333,9 @@ As a Zephyr User, I need to understand how to configure the external C libraries
 DISCUSSION_DATE: >>>
 TBD: Revisit after subset defined.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-2
 
 [/SECTION]
 
@@ -1670,9 +1669,6 @@ UID: ZEP-27
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Timers
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-6
 TITLE: Kernel Clock
 STATEMENT: >>>
 Zephyr shall provide a interface for checking the current value of the real-time clock.
@@ -1683,15 +1679,15 @@ As a Zephyr OS user, I want to be able to track the passed real time in the OS w
 DISCUSSION_DATE: >>>
 pf-ok
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-6
 
 [REQUIREMENT]
 UID: ZEP-28
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Timers
-REFS:
-- TYPE: Parent
-  VALUE: ZEP-6
 TITLE: Call functions in interrupt context
 STATEMENT: >>>
 Zephyr shall provide an interface to schedule user mode call back function triggered by a real time clock value.
@@ -1702,6 +1698,9 @@ As a Zephyr OS user, I want to be able to execute functions in the interrupt con
 DISCUSSION_DATE: >>>
 pf-ok
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-6
 
 [/SECTION]
 


### PR DESCRIPTION
This work concludes the assignment of ZEP-based UIDs to all existing Zephyr requirements.

The last auto-generated UID is `ZEP-121` which matches the total number of requirements.

The first two commits update the requirements to be in accordance with the latest StrictDoc conventions: 
- The deprecated `REFS` field has been renamed to the `RELATIONS` field.
- The `RELATIONS` field is now the last field in each requirement.

The third commit auto-generates the remaining UIDs.

The changes can be reviewed commit-by-commit. 