### PR TITLE
(shelved) gregshue/zep semaphore reqs

### DIFF
--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1155,6 +1155,23 @@ the Zephyr RTOS shall accomplish all of the following:
 [SECTION]
 TITLE: Semaphore Take
 
+[REQUIREMENT]
+UID: ZEP-129
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Take while Available
+STATEMENT: >>>
+While a Counting Semaphore count is > 0,
+
+When a takes that Counting Semaphore,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- decrement by 1 the count of that Counting Semaphore;
+- indicate SUCCESS to the taking thread.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1117,6 +1117,23 @@ TITLE: Initialization
 TITLE: Semaphore Give
 
 [REQUIREMENT]
+UID: ZEP-128
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Give without Waiting Threads
+STATEMENT: >>>
+While no thread is waiting for a Counting Semaphore,
+
+When a thread gives that Counting Semaphore,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- increase the Semaphore Count by 1;
+- indicate SUCCESS to the giving thread.
+<<<
+
+[REQUIREMENT]
 UID: ZEP-127
 STATUS: Draft
 TYPE: Functional

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1116,6 +1116,23 @@ TITLE: Initialization
 [SECTION]
 TITLE: Semaphore Give
 
+[REQUIREMENT]
+UID: ZEP-127
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Give while Thread Waiting
+STATEMENT: >>>
+While a thread is waiting for a Counting Semaphore,
+
+When a thread gives that Counting Semaphore,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- unblock the highest priority thread waiting for that Counting Semaphore;
+- indicate SUCCESS to the giving thread.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1113,6 +1113,11 @@ TITLE: Initialization
 
 [/SECTION]
 
+[SECTION]
+TITLE: Semaphore Give
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1111,6 +1111,19 @@ TITLE: Counting Semaphore
 [SECTION]
 TITLE: Initialization
 
+[REQUIREMENT]
+UID: ZEP-134
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Build-Time Allocation and Initialization
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface for a Counting Semaphore to accomplish all of the following at build-time:
+
+- statically allocating the Counting Semaphore;
+- statically initialize the Counting Semaphore with the provided count limit and initial count.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1219,6 +1219,22 @@ the Zephyr RTOS shall accomplish all of the following:
 - reschedule the waiting thread.
 <<<
 
+[REQUIREMENT]
+UID: ZEP-133
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Take Unblocked by Waiting Period Timeout
+STATEMENT: >>>
+When the waiting thread is unblocked by the expiration of the waiting period,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- resume the waiting thread;
+- indicate TIMEDOUT to the waiting thread;
+- reschedule the waiting thread.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1124,6 +1124,19 @@ The Zephyr RTOS shall expose an interface for a Counting Semaphore to accomplish
 - statically initialize the Counting Semaphore with the provided count limit and initial count.
 <<<
 
+[REQUIREMENT]
+UID: ZEP-135
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Dynamic Initialization
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface to dynamically initialize a Counting Semaphore which requires the following information:
+
+- initial count of the Counting Semaphore;
+- count limit of the Counting Semaphore.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1123,6 +1123,11 @@ TITLE: Semaphore Take
 
 [/SECTION]
 
+[SECTION]
+TITLE: Semaphore Count
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1108,6 +1108,11 @@ execution explicitly.
 [SECTION]
 TITLE: Counting Semaphore
 
+[SECTION]
+TITLE: Initialization
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1266,6 +1266,18 @@ the Zephyr RTOS shall accomplish all of the following:
 [SECTION]
 TITLE: Semaphore Count
 
+[REQUIREMENT]
+UID: ZEP-136
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Current Count
+STATEMENT: >>>
+When the Counting Semaphore current count is requested,
+
+the Zephyr RTOS shall report the current count of the Counting Semaphore.
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1105,6 +1105,11 @@ allows for asynchronous communication, where threads do not need to synchronize 
 execution explicitly.
 <<<
 
+[SECTION]
+TITLE: Counting Semaphore
+
+[/SECTION]
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1118,6 +1118,11 @@ TITLE: Semaphore Give
 
 [/SECTION]
 
+[SECTION]
+TITLE: Semaphore Take
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1172,6 +1172,23 @@ the Zephyr RTOS shall accomplish all of the following:
 - indicate SUCCESS to the taking thread.
 <<<
 
+[REQUIREMENT]
+UID: ZEP-130
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Take with TIMEOUT > 0 blocks if not Available
+STATEMENT: >>>
+While a Counting Semaphore count is 0,
+
+When a thread takes that Counting Semaphore with a waiting TIMEOUT > 0,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- block the taking thread waiting for the availability of that Counting Semaphore;
+- enter the waiting period with a duration TIMEOUT.
+<<<
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1173,6 +1173,20 @@ the Zephyr RTOS shall accomplish all of the following:
 <<<
 
 [REQUIREMENT]
+UID: ZEP-131
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Take w/o blocking when not Available
+STATEMENT: >>>
+While a Counting Semaphore count is 0,
+
+When a thread takes that Counting Semaphore without allowing blocking,
+
+the Zephyr RTOS shall indicate NOT AVAILABLE to the taking thread.
+<<<
+
+[REQUIREMENT]
 UID: ZEP-130
 STATUS: Draft
 TYPE: Functional

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -1203,6 +1203,22 @@ the Zephyr RTOS shall accomplish all of the following:
 - enter the waiting period with a duration TIMEOUT.
 <<<
 
+[REQUIREMENT]
+UID: ZEP-132
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Counting Semaphore
+TITLE: Semaphore Take Unblocked by Giving Thread
+STATEMENT: >>>
+When the waiting thread is unblocked by a giving thread,
+
+the Zephyr RTOS shall accomplish all of the following:
+
+- deactivate the waiting period;
+- indicate SUCCESS to the waiting thread;
+- reschedule the waiting thread.
+<<<
+
 [/SECTION]
 
 [SECTION]


### PR DESCRIPTION
Preliminary Low-level Counting Semaphore requirements in EARS syntax. Please note that these requirements are expressed in terms of observable behaviors so are not specific to any implementation. (These requirements could be met by an RTOS implemented in C, C++, or Rust.)  

Requirement statements at this level are sufficient to design verification tests covering full functionality. Once the Counting Semaphore interface is specified and stubs written, the full-functionality verification tests could be implemented, and failure detection verified as the code-under-test evolves to meet requirements.  

Code coverage tools are necessary to identify any unspecified logic and/or data present in the implementation.