### PR TITLE
Gregshue/zep cpu arch ifc req

### DIFF
--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -159,6 +159,16 @@ STATEMENT: >>>
 The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to disable interrupt processing. 
 <<<
 
+[REQUIREMENT]
+UID: ZEP-132
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Enabled Status
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to report the enabled status of interrupt processing.
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -139,6 +139,16 @@ STATEMENT: >>>
 The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to report the lock status of interrupt processing. 
 <<<
 
+[REQUIREMENT]
+UID: ZEP-130
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Disable
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to disable interrupt processing. 
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -106,6 +106,11 @@ RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-1
 
+[SECTION]
+TITLE: Interrupt Management
+
+[/SECTION]
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -109,6 +109,16 @@ RELATIONS:
 [SECTION]
 TITLE: Interrupt Management
 
+[REQUIREMENT]
+UID: ZEP-127
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Lock
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to lock interrupt processing. 
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -171,6 +171,11 @@ The Zephyr RTOS shall expose an interface declaration for HW Architecture-specif
 
 [/SECTION]
 
+[SECTION]
+TITLE: Misc
+
+[/SECTION]
+
 [/SECTION]
 
 [SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -116,7 +116,7 @@ TYPE: Interface
 COMPONENT: HW Architecture 
 TITLE: Interrupts Lock
 STATEMENT: >>>
-The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to lock interrupt processing. 
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to lock interrupt processing.
 <<<
 
 [REQUIREMENT]
@@ -126,7 +126,7 @@ TYPE: Interface
 COMPONENT: HW Architecture 
 TITLE: Interrupts Unlock
 STATEMENT: >>>
-The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to unlock interrupt processing. 
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to unlock interrupt processing.
 <<<
 
 [REQUIREMENT]
@@ -136,7 +136,7 @@ TYPE: Interface
 COMPONENT: HW Architecture 
 TITLE: Interrupts Lock Status
 STATEMENT: >>>
-The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to report the lock status of interrupt processing. 
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to report the lock status of interrupt processing.
 <<<
 
 [REQUIREMENT]
@@ -146,7 +146,7 @@ TYPE: Interface
 COMPONENT: HW Architecture 
 TITLE: Interrupts Enable
 STATEMENT: >>>
-The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to enable interrupt processing. 
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to enable interrupt processing.
 <<<
 
 [REQUIREMENT]
@@ -156,7 +156,7 @@ TYPE: Interface
 COMPONENT: HW Architecture 
 TITLE: Interrupts Disable
 STATEMENT: >>>
-The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to disable interrupt processing. 
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to disable interrupt processing.
 <<<
 
 [REQUIREMENT]
@@ -173,6 +173,16 @@ The Zephyr RTOS shall expose an interface declaration for HW Architecture-specif
 
 [SECTION]
 TITLE: Misc
+
+[REQUIREMENT]
+UID: ZEP-133
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture
+TITLE: NOP
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to consume execution cycles.
+<<<
 
 [/SECTION]
 

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -119,6 +119,16 @@ STATEMENT: >>>
 The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to lock interrupt processing. 
 <<<
 
+[REQUIREMENT]
+UID: ZEP-128
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Unlock
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to unlock interrupt processing. 
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -129,6 +129,16 @@ STATEMENT: >>>
 The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to unlock interrupt processing. 
 <<<
 
+[REQUIREMENT]
+UID: ZEP-129
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Lock Status
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to report the lock status of interrupt processing. 
+<<<
+
 [/SECTION]
 
 [/SECTION]

--- a/docs/zephyr_02_functional_requirements.sdoc
+++ b/docs/zephyr_02_functional_requirements.sdoc
@@ -140,6 +140,16 @@ The Zephyr RTOS shall expose an interface declaration for HW Architecture-specif
 <<<
 
 [REQUIREMENT]
+UID: ZEP-131
+STATUS: Draft
+TYPE: Interface
+COMPONENT: HW Architecture 
+TITLE: Interrupts Enable
+STATEMENT: >>>
+The Zephyr RTOS shall expose an interface declaration for HW Architecture-specific logic to enable interrupt processing. 
+<<<
+
+[REQUIREMENT]
 UID: ZEP-130
 STATUS: Draft
 TYPE: Interface


### PR DESCRIPTION
The Zephyr Kernel(?) defines the HW Architecture interface used by the Zephyr Kernel. This PR captures the specific requirements for some of the API functions related to interrupt enable/disable/lock/unlock. These methods are needed to establish critical sections for atomic operations. 

NOTE: The requirements within the Safety Scope must indicate how and where the HW Architecture APi is used by the Zephyr Kernel.