### PR TITLE
Software requirements: extract data passing to fragment

### DIFF
--- a/docs/software_requirements/data_passing.sdoc
+++ b/docs/software_requirements/data_passing.sdoc
@@ -1,0 +1,32 @@
+[DOCUMENT]
+TITLE: Data Passing
+REQ_PREFIX: ZEP-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[REQUIREMENT]
+UID: ZEP-89
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Data Passing
+TITLE: Traditional FIFO Queue
+STATEMENT: >>>
+The Zephyr RTOS shall provide a kernel object that implements a traditional first in, first out (FIFO) queue, allowing threads and ISRs to add and remove a limited number of 32-bit data values.
+<<<
+USER_STORY: >>>
+As a Zephyr RTOS user I want to be able to exchange 1 to N data objects between different threads and ISR in a thread-safe manner with a first-in-first-out (queue) behaviour.
+<<<
+
+[REQUIREMENT]
+UID: ZEP-90
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Data Passing
+TITLE: Traditional LIFO queue
+STATEMENT: >>>
+The Zephyr RTOS shall provide a kernel object that implements a traditional last in, first out (LIFO) queue, allowing threads and ISRs to add and remove a limited number of 32-bit data values.
+<<<
+USER_STORY: >>>
+As a Zephyr RTOS user I want to be able to exchange 1 to N data objects between different threads and ISR in a thread-safe manner with a last-in-first-out (stack) behaviour.
+<<<

--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -809,36 +809,8 @@ As a Zephyr RTOS user I want a most efficient and least fragmentation prone dyna
 
 [/SECTION]
 
-[SECTION]
-TITLE: Data Passing
-
-[REQUIREMENT]
-UID: ZEP-89
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Data Passing
-TITLE: Traditional FIFO Queue
-STATEMENT: >>>
-The Zephyr RTOS shall provide a kernel object that implements a traditional first in, first out (FIFO) queue, allowing threads and ISRs to add and remove a limited number of 32-bit data values.
-<<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to exchange 1 to N data objects between different threads and ISR in a thread-safe manner with a first-in-first-out (queue) behaviour.
-<<<
-
-[REQUIREMENT]
-UID: ZEP-90
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Data Passing
-TITLE: Traditional LIFO queue
-STATEMENT: >>>
-The Zephyr RTOS shall provide a kernel object that implements a traditional last in, first out (LIFO) queue, allowing threads and ISRs to add and remove a limited number of 32-bit data values.
-<<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to exchange 1 to N data objects between different threads and ISR in a thread-safe manner with a last-in-first-out (stack) behaviour.
-<<<
-
-[/SECTION]
+[DOCUMENT_FROM_FILE]
+FILE: data_passing.sdoc
 
 [SECTION]
 TITLE: Mutex


### PR DESCRIPTION
Summary of the changes:

- Fragment document created from the section "Data Passing".

**StrictDoc 0.0.53 version is needed for this changeset to work.**