### PR TITLE
Software requirements: extract mutex to fragment

### DIFF
--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -38,29 +38,8 @@ FILE: memory_objects.sdoc
 [DOCUMENT_FROM_FILE]
 FILE: data_passing.sdoc
 
-[SECTION]
-TITLE: Mutex
-
-[REQUIREMENT]
-UID: ZEP-91
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Mutex
-TITLE: Mutex Kernel Object
-STATEMENT: >>>
-The Zephyr RTOS shall support resource synchronization. (Note synchronization can be for memory access, and mutex may be one implementation, but not the only one).
-<<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to sychonize threads when accessing common resources, where the thread shall have the option to:
-- wait eternally until the resources becomes available.
-- immediately return with a negative message if the resource is not available and allow the thread to continue.
-- wait for a given time for the resource to become available or return with a negative message.
-<<<
-REVIEW_COMMENT: >>>
-Concern over phrase recursive.  What is it MUTEXing? Memory Management?
-<<<
-
-[/SECTION]
+[DOCUMENT_FROM_FILE]
+FILE: mutex.sdoc
 
 [DOCUMENT_FROM_FILE]
 FILE: power_management.sdoc

--- a/docs/software_requirements/mutex.sdoc
+++ b/docs/software_requirements/mutex.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Mutex
+REQ_PREFIX: ZEP-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[REQUIREMENT]
+UID: ZEP-91
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Mutex
+TITLE: Mutex Kernel Object
+STATEMENT: >>>
+The Zephyr RTOS shall support resource synchronization. (Note synchronization can be for memory access, and mutex may be one implementation, but not the only one).
+<<<
+USER_STORY: >>>
+As a Zephyr RTOS user I want to be able to sychonize threads when accessing common resources, where the thread shall have the option to:
+- wait eternally until the resources becomes available.
+- immediately return with a negative message if the resource is not available and allow the thread to continue.
+- wait for a given time for the resource to become available or return with a negative message.
+<<<
+REVIEW_COMMENT: >>>
+Concern over phrase recursive.  What is it MUTEXing? Memory Management?
+<<<


### PR DESCRIPTION
Summary of the changes:

- Fragment document created from the section "Mutex".

**StrictDoc 0.0.53 version is needed for this changeset to work.**