### PR TITLE
Software requirements: extract power mgmt to fragment

### DIFF
--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -864,45 +864,8 @@ Concern over phrase recursive.  What is it MUTEXing? Memory Management?
 
 [/SECTION]
 
-[SECTION]
-TITLE: Power Management
-
-[REQUIREMENT]
-UID: ZEP-92
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Power Management
-TITLE: Power State Control
-STATEMENT: >>>
-The Zephyr RTOS shall provide control over changes to system power states.
-<<<
-USER_STORY: >>>
-See ZEP104
-+
-When the power state is changed I want to get an notification in order for specific parts of my application to react accordingly.
-<<<
-
-[REQUIREMENT]
-UID: ZEP-93
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Power Management
-TITLE: Power Management - TBD
-STATEMENT: >>>
-TBD
-<<<
-
-[REQUIREMENT]
-UID: ZEP-94
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Power Management
-TITLE: Notification of changes to system power states
-STATEMENT: >>>
-The Zephyr RTOS shall provide notification of changes to system power states.
-<<<
-
-[/SECTION]
+[DOCUMENT_FROM_FILE]
+FILE: power_management.sdoc
 
 [SECTION]
 TITLE: Thread Communication

--- a/docs/software_requirements/power_management.sdoc
+++ b/docs/software_requirements/power_management.sdoc
@@ -1,0 +1,41 @@
+[DOCUMENT]
+TITLE: Power Management
+REQ_PREFIX: ZEP-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[REQUIREMENT]
+UID: ZEP-92
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Power State Control
+STATEMENT: >>>
+The Zephyr RTOS shall provide control over changes to system power states.
+<<<
+USER_STORY: >>>
+See ZEP104
++
+When the power state is changed I want to get an notification in order for specific parts of my application to react accordingly.
+<<<
+
+[REQUIREMENT]
+UID: ZEP-93
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Power Management - TBD
+STATEMENT: >>>
+TBD
+<<<
+
+[REQUIREMENT]
+UID: ZEP-94
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Notification of changes to system power states
+STATEMENT: >>>
+The Zephyr RTOS shall provide notification of changes to system power states.
+<<<


### PR DESCRIPTION
Summary of the changes:

- Fragment document created from the section "Power Management".

**StrictDoc 0.0.53 version is needed for this changeset to work.**