### PR TITLE
Software requirements: create system init fragment

### DIFF
--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -18,6 +18,9 @@ FILE: device_driver_api.sdoc
 FILE: exception_and_error_handling.sdoc
 
 [DOCUMENT_FROM_FILE]
+FILE: system_initialization.sdoc
+
+[DOCUMENT_FROM_FILE]
 FILE: file_system.sdoc
 
 [DOCUMENT_FROM_FILE]

--- a/docs/software_requirements/system_initialization.sdoc
+++ b/docs/software_requirements/system_initialization.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: System Initialization
+REQ_PREFIX: ZEP-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[FREETEXT]
+
+TBD
+
+[/FREETEXT]


### PR DESCRIPTION
Summary of the changes:

- Fragment document created for a section "System Initialization".

**StrictDoc 0.0.53 version is needed for this changeset to work.**