### PR TITLE
System requirements: extract grammar to fragment

### DIFF
--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -3,35 +3,7 @@ TITLE: Zephyr System Requirements
 REQ_PREFIX: ZEP-
 
 [GRAMMAR]
-ELEMENTS:
-- TAG: REQUIREMENT
-  FIELDS:
-  - TITLE: UID
-    TYPE: String
-    REQUIRED: False
-  - TITLE: STATUS
-    TYPE: String
-    REQUIRED: False
-  - TITLE: TYPE
-    TYPE: String
-    REQUIRED: False
-  - TITLE: COMPONENT
-    TYPE: String
-    REQUIRED: False
-  - TITLE: TITLE
-    TYPE: String
-    REQUIRED: False
-  - TITLE: STATEMENT
-    TYPE: String
-    REQUIRED: False
-  - TITLE: USER_STORY
-    TYPE: String
-    REQUIRED: False
-  - TITLE: REVIEW_COMMENT
-    TYPE: String
-    REQUIRED: False
-  RELATIONS:
-  - TYPE: Parent
+IMPORT_FROM_FILE: system_requirements.sgra
 
 [REQUIREMENT]
 UID: ZEP-1

--- a/docs/system_requirements/system_requirements.sgra
+++ b/docs/system_requirements/system_requirements.sgra
@@ -1,0 +1,30 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TYPE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMPONENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: USER_STORY
+    TYPE: String
+    REQUIRED: False
+  - TITLE: REVIEW_COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent


### PR DESCRIPTION
Summary of the changes:

- Fragment document created for grammar.

**StrictDoc 0.0.53 version is needed for this changeset to work.**