### PR TITLE
Stakeholder Needs extraction of User Stories

### DIFF
--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -118,3 +118,12 @@ TITLE: Power Management
 STATEMENT: >>>
 As a Zephyr RTOS user I want to be able to control the power mode of the MCU and its peripherals to take advantage of the hardware features and to be able to implement low power or battery driven long life applications.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-137
+STATUS: Draft
+TYPE: Need
+TITLE: Multiple CPU scheduling
+STATEMENT: >>>
+As a Zephyr RTOS user I want Zephyr OS to run on MCUs/CPUs with one or more CPU cores.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -64,3 +64,12 @@ TITLE: Device Driver Abstraction
 STATEMENT: >>>
 As a Zephyr RTOS user I want my application to be portable between different MCU architectures (ARM Cortex-M/A, Intel x86, RISCV etc.) and MCU vendors (STM, NXP, Intel, etc.) without having to change the MCU peripherals access.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-131
+STATUS: Draft
+TYPE: Need
+TITLE: Fatal error and exception handling
+STATEMENT: >>>
+As a Zephyr RTOS user I want errors and exceptions to handled and react according to my applications requirements (e.g. reach/establish the applications safety state).
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -163,3 +163,12 @@ TITLE: Thread support
 STATEMENT: >>>
 As a Zephyr RTOS user, I want to be able to have support for the kernel objects named threads for processing work.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-142
+STATUS: Draft
+TYPE: Need
+TITLE: Thread management
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to be able to manage the execute of multiple threads with different priorities.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -28,3 +28,12 @@ ELEMENTS:
 [FREETEXT]
 TBD
 [/FREETEXT]
+
+[STAKEHOLDER_NEED]
+UID: ZEP-127
+STATUS: Draft
+TYPE: Need
+TITLE: Architecture Layer Interface
+STATEMENT: >>>
+As a Zephyr RTOS user I want to be able to easily switch my application to a different MCU architecture (x86, ARM Cortex-M/A, RISCV etc.).
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -154,3 +154,12 @@ TITLE: Counting Semaphore
 STATEMENT: >>>
 As a software developer threaded with implementing resource management in our real-time operating system (RTOS), I want to integrate a semaphore synchronization primitive to facilitate coordinated access to shared resources among multiple threads.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-141
+STATUS: Draft
+TYPE: Need
+TITLE: Thread support
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to be able to have support for the kernel objects named threads for processing work.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -37,3 +37,12 @@ TITLE: Architecture Layer Interface
 STATEMENT: >>>
 As a Zephyr RTOS user I want to be able to easily switch my application to a different MCU architecture (x86, ARM Cortex-M/A, RISCV etc.).
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-128
+STATUS: Draft
+TYPE: Need
+TITLE: Support multiprocessor management
+STATEMENT: >>>
+As a Zephyr RTOS user I want to use Zephyr OS on multi core (SMP-)MCUs/MPUs.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Zephyr Stakeholder Needs
+REQ_PREFIX: ZEP-
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: STAKEHOLDER_NEED
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TYPE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[FREETEXT]
+TBD
+[/FREETEXT]

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -127,3 +127,12 @@ TITLE: Multiple CPU scheduling
 STATEMENT: >>>
 As a Zephyr RTOS user I want Zephyr OS to run on MCUs/CPUs with one or more CPU cores.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-138
+STATUS: Draft
+TYPE: Need
+TITLE: Scheduling
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to be able to control which thread will run on which CPU.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -145,3 +145,12 @@ TITLE: Mutex
 STATEMENT: >>>
 As a Zephyr RTOS user I want to able to exchange information between threads in a thread-safe manner guaranteeing data consistence.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-140
+STATUS: Draft
+TYPE: Need
+TITLE: Counting Semaphore
+STATEMENT: >>>
+As a software developer threaded with implementing resource management in our real-time operating system (RTOS), I want to integrate a semaphore synchronization primitive to facilitate coordinated access to shared resources among multiple threads.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -55,3 +55,12 @@ TITLE: Support Subset of Standard C Library
 STATEMENT: >>>
 As a Zephyr RTOS user I want to have a selection of standard C library implementations e.g. a full extend and a minimal with a smaller footprint or a particular fast executing implementation.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-130
+STATUS: Draft
+TYPE: Need
+TITLE: Device Driver Abstraction
+STATEMENT: >>>
+As a Zephyr RTOS user I want my application to be portable between different MCU architectures (ARM Cortex-M/A, Intel x86, RISCV etc.) and MCU vendors (STM, NXP, Intel, etc.) without having to change the MCU peripherals access.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -73,3 +73,12 @@ TITLE: Fatal error and exception handling
 STATEMENT: >>>
 As a Zephyr RTOS user I want errors and exceptions to handled and react according to my applications requirements (e.g. reach/establish the applications safety state).
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-132
+STATUS: Draft
+TYPE: Need
+TITLE: Common File system operation support
+STATEMENT: >>>
+As a Zephyr RTOS user I want a posix / c like file system access to store data.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -136,3 +136,12 @@ TITLE: Scheduling
 STATEMENT: >>>
 As a Zephyr RTOS user, I want to be able to control which thread will run on which CPU.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-139
+STATUS: Draft
+TYPE: Need
+TITLE: Mutex
+STATEMENT: >>>
+As a Zephyr RTOS user I want to able to exchange information between threads in a thread-safe manner guaranteeing data consistence.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -190,3 +190,12 @@ TITLE: Timers
 STATEMENT: >>>
 As a Zephyr RTOS user, I want to start, suspend, resume and stop timers which shall trigger an event on a set expiration time.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-145
+STATUS: Draft
+TYPE: Need
+TITLE: Tracing
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to be able to trace different OS operations.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -181,3 +181,12 @@ TITLE: Thread priority
 STATEMENT: >>>
 As a Zephyr RTOS user, I want to be able to give my threads different priorities for execution.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-144
+STATUS: Draft
+TYPE: Need
+TITLE: Timers
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to start, suspend, resume and stop timers which shall trigger an event on a set expiration time.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -172,3 +172,12 @@ TITLE: Thread management
 STATEMENT: >>>
 As a Zephyr RTOS user, I want to be able to manage the execute of multiple threads with different priorities.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-143
+STATUS: Draft
+TYPE: Need
+TITLE: Thread priority
+STATEMENT: >>>
+As a Zephyr RTOS user, I want to be able to give my threads different priorities for execution.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -109,3 +109,12 @@ TITLE: Memory Management framework
 STATEMENT: >>>
 As a Zephyr RTOS user I want memory to be allocated and protected to my application threads preventing mistakenly access to foreign memory as far as the hardware allows.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-136
+STATUS: Draft
+TYPE: Need
+TITLE: Power Management
+STATEMENT: >>>
+As a Zephyr RTOS user I want to be able to control the power mode of the MCU and its peripherals to take advantage of the hardware features and to be able to implement low power or battery driven long life applications.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -91,3 +91,12 @@ TITLE: Interrupt Service Routine
 STATEMENT: >>>
 As a Zephyr RTOS user I want interrupts to be handled synchronously in response to a hardware or software interrupt request with a minimum latency, preempting threads and, as far as the hardware allows, lower priority interrupt service routines.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-134
+STATUS: Draft
+TYPE: Need
+TITLE: Logging
+STATEMENT: >>>
+As a Zephyr RTOS user I want to be able to log application defined events as well as framework exceptions.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -100,3 +100,12 @@ TITLE: Logging
 STATEMENT: >>>
 As a Zephyr RTOS user I want to be able to log application defined events as well as framework exceptions.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-135
+STATUS: Draft
+TYPE: Need
+TITLE: Memory Management framework
+STATEMENT: >>>
+As a Zephyr RTOS user I want memory to be allocated and protected to my application threads preventing mistakenly access to foreign memory as far as the hardware allows.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -82,3 +82,12 @@ TITLE: Common File system operation support
 STATEMENT: >>>
 As a Zephyr RTOS user I want a posix / c like file system access to store data.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-133
+STATUS: Draft
+TYPE: Need
+TITLE: Interrupt Service Routine
+STATEMENT: >>>
+As a Zephyr RTOS user I want interrupts to be handled synchronously in response to a hardware or software interrupt request with a minimum latency, preempting threads and, as far as the hardware allows, lower priority interrupt service routines.
+<<<

--- a/docs/stakeholder_needs.sdoc
+++ b/docs/stakeholder_needs.sdoc
@@ -46,3 +46,12 @@ TITLE: Support multiprocessor management
 STATEMENT: >>>
 As a Zephyr RTOS user I want to use Zephyr OS on multi core (SMP-)MCUs/MPUs.
 <<<
+
+[STAKEHOLDER_NEED]
+UID: ZEP-129
+STATUS: Draft
+TYPE: Need
+TITLE: Support Subset of Standard C Library
+STATEMENT: >>>
+As a Zephyr RTOS user I want to have a selection of standard C library implementations e.g. a full extend and a minimal with a smaller footprint or a particular fast executing implementation.
+<<<

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -27,15 +27,14 @@ TITLE: Support multiprocessor management
 STATEMENT: >>>
 The Zephyr RTOS shall support symmetric multiprocessing on multiple cores.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to use Zephyr OS on multi core (SMP-)MCUs/MPUs.
-<<<
 REVIEW_COMMENT: >>>
 From the Docs: No special application code needs to be written to take advantage of this feature
 <<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-1
+- TYPE: Parent
+  VALUE: ZEP-128
 
 [REQUIREMENT]
 UID: ZEP-2

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -196,9 +196,9 @@ TITLE: Mutex
 STATEMENT: >>>
 The Zephyr RTOS shall provide an interface for managing communication between threads.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to able to exchange information between threads in a thread-safe manner guaranteeing data consistence.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-139
 
 [REQUIREMENT]
 UID: ZEP-99

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -45,9 +45,6 @@ TITLE: Support Subset of Standard C Library
 STATEMENT: >>>
 The Zephyr RTOS shall support a subset of the standard C library.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to have a selection of standard C library implementations e.g. a full extend and a minimal with a smaller footprint or a particular fast executing implementation.
-<<<
 REVIEW_COMMENT: >>>
 Can we limit the type of C library implementations? Testing might be hell if we do not limit ourselves to the ones defined? Like "minimal libc" and "newlib". Will it make sense to pull minimal Libc into the certification scope?
 
@@ -55,6 +52,9 @@ Clarification: Would prefer to cover the scope part first. Talking about the hoo
 
 TBD: The requirement needs refinement.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-129
 
 [REQUIREMENT]
 UID: ZEP-36

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -209,9 +209,9 @@ TITLE: Counting Semaphore
 STATEMENT: >>>
 The system shall implement a semaphore synchronization primitive for coordinating access to shared resources among multiple threads.
 <<<
-USER_STORY: >>>
-As a software developer threaded with implementing resource management in our real-time operating system (RTOS), I want to integrate a semaphore synchronization primitive to facilitate coordinated access to shared resources among multiple threads.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-140
 
 [/SECTION]
 

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -65,12 +65,12 @@ TITLE: Device Driver Abstraction
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for managing device drivers and peripherals.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want my application to be portable between different MCU architectures (ARM Cortex-M/A, Intel x86, RISCV etc.) and MCU vendors (STM, NXP, Intel, etc.) without having to change the MCU peripherals access.
-<<<
 REVIEW_COMMENT: >>>
 TBD: Title seems to need refinement. Also, this requirement's user story seems to be identical to that of ZEP-1.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-130
 
 [REQUIREMENT]
 UID: ZEP-37

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -107,9 +107,9 @@ TITLE: Interrupt Service Routine
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for interrupt management.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want interrupts to be handled synchronously in response to a hardware or software interrupt request with a minimum latency, preempting threads and, as far as the hardware allows, lower priority interrupt service routines.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-133
 
 [REQUIREMENT]
 UID: ZEP-40

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -178,9 +178,9 @@ TITLE: Scheduling
 STATEMENT: >>>
 The Zephyr RTOS shall provide an interface to assign a thread to a specific CPU.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to be able to control which thread will run on which CPU.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-138
 
 [/SECTION]
 

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -271,9 +271,9 @@ TITLE: Timers
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for managing time-based events.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to start, suspend, resume and stop timers which shall trigger an event on a set expiration time.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-144
 
 [REQUIREMENT]
 UID: ZEP-7

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -240,12 +240,12 @@ TITLE: Thread management
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for managing multiple threads of execution.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to be able to manage the execute of multiple threads with different priorities.
-<<<
 REVIEW_COMMENT: >>>
 TBD: Nothing about priorities...
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-142
 
 [REQUIREMENT]
 UID: ZEP-122

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -256,9 +256,9 @@ TITLE: Thread priority
 STATEMENT: >>>
 Threads shall have a priority.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to be able to give my threads different priorities for execution.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-143
 
 [/SECTION]
 

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -227,9 +227,9 @@ TITLE: Thread support
 STATEMENT: >>>
 The Zephyr RTOS shall support threads.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to be able to have support for the kernel objects named threads for processing work.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-141
 
 [REQUIREMENT]
 UID: ZEP-5

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -14,9 +14,9 @@ TITLE: Architecture Layer Interface
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework to communicate with a set of hardware architectural services.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to easily switch my application to a different MCU architecture (x86, ARM Cortex-M/A, RISCV etc.).
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-127
 
 [REQUIREMENT]
 UID: ZEP-3

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -81,9 +81,9 @@ TITLE: Fatal error and exception handling
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for error and exception handling.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want errors and exceptions to handled and react according to my applications requirements (e.g. reach/establish the applications safety state).
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-131
 
 [REQUIREMENT]
 UID: ZEP-38

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -284,9 +284,9 @@ TITLE: Tracing
 STATEMENT: >>>
 Zepyhr shall provide a framework mechanism for tracing low level system operations  (NOTE: system calls, interrupts, kernel calls, thread, synchronization, etc.).
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user, I want to be able to trace different OS operations.
-<<<
 REVIEW_COMMENT: >>>
 TBD: What are low level system operations in this context?
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-145

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -165,9 +165,9 @@ TITLE: Multiple CPU scheduling
 STATEMENT: >>>
 The Zephyr RTOS shall support scheduling of threads on multiple hardware CPUs.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want Zephyr OS to run on MCUs/CPUs with one or more CPU cores.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-137
 
 [REQUIREMENT]
 UID: ZEP-4

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -94,9 +94,9 @@ TITLE: Common File system operation support
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for managing file system access.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want a posix / c like file system access to store data.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-132
 
 [REQUIREMENT]
 UID: ZEP-39

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -136,9 +136,9 @@ TITLE: Memory Management framework
 STATEMENT: >>>
 The Zephyr RTOS shall support a memory management framework.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want memory to be allocated and protected to my application threads preventing mistakenly access to foreign memory as far as the hardware allows.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-135
 
 [REQUIREMENT]
 UID: ZEP-42

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -120,12 +120,12 @@ TITLE: Logging
 STATEMENT: >>>
 The Zephyr RTOS shall provide a framework for logging events.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to log application defined events as well as framework exceptions.
-<<<
 REVIEW_COMMENT: >>>
 Nicole: TBD: we need to have logging in the safety scope?
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-134
 
 [REQUIREMENT]
 UID: ZEP-41

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -149,9 +149,9 @@ TITLE: Power Management
 STATEMENT: >>>
 The Zephyr RTOS shall provide an interface to control hardware power states.
 <<<
-USER_STORY: >>>
-As a Zephyr RTOS user I want to be able to control the power mode of the MCU and its peripherals to take advantage of the hardware features and to be able to implement low power or battery driven long life applications.
-<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-136
 
 [SECTION]
 TITLE: Multi core and SMP


### PR DESCRIPTION
Add User Needs sdoc directory to hold User Need items so they can be referred to from Requirement items rather than copied into the USER_STORY. This is necessary since one User Need may be referenced by multiple requirement items, and one requirement item may need to reference multiple User Needs that it helps fulfill.