### PR TITLE
Create glossary skeleton w/ std terms

### DIFF
--- a/docs/glossary/Zephyr_RTOS.sdoc
+++ b/docs/glossary/Zephyr_RTOS.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Zephyr RTOS
+
+[FREETEXT]
+Zephyr RTOS: TBD
+[/FREETEXT]

--- a/docs/glossary/boot.sdoc
+++ b/docs/glossary/boot.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: boot
+
+[FREETEXT]
+boot.
+
+(1) to initialize a computer system by clearing memory and reloading the operating system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Note: derived from bootstrap
+[/FREETEXT]

--- a/docs/glossary/bootstrap.sdoc
+++ b/docs/glossary/bootstrap.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: bootstrap
+
+[FREETEXT]
+bootstrap.
+
+(1) short computer program that is permanently resident or easily loaded into a computer and whose execution brings a larger program, such as an operating system or its loader, into memory (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(2) to use a program to bring up a larger program, such as an operating system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Example: null
+[/FREETEXT]

--- a/docs/glossary/central_processing_unit_(CPU).sdoc
+++ b/docs/glossary/central_processing_unit_(CPU).sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: central processing unit (CPU)
+
+[FREETEXT]
+CPU.
+
+(1) central processing unit (IEEE 1012-2016 IEEE Standard for System, Software, and Hardware Verification and Validation, 3.1)
+[/FREETEXT]

--- a/docs/glossary/core.sdoc
+++ b/docs/glossary/core.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: core
+
+[FREETEXT]
+core.
+
+(1) processing unit in a computer or processor which manages instructions, data, and operations (ISO/IEC/IEEE 24765c:2014)
+[/FREETEXT]

--- a/docs/glossary/critical_section.sdoc
+++ b/docs/glossary/critical_section.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: critical section
+
+[FREETEXT]
+critical section.
+
+(1) section of a task's internal logic that is executed mutually exclusively with other tasks (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/deadlock.sdoc
+++ b/docs/glossary/deadlock.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: deadlock
+
+[FREETEXT]
+deadlock.
+
+(1) situation in which computer processing is suspended because two or more devices or processes are each awaiting resources assigned to the others (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(2) situation in which two or more tasks are suspended indefinitely because each task is waiting for a resource acquired by another task (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: lockout
+[/FREETEXT]

--- a/docs/glossary/embedded_computer_system.sdoc
+++ b/docs/glossary/embedded_computer_system.sdoc
@@ -1,0 +1,14 @@
+[DOCUMENT]
+TITLE: embedded computer system
+
+[FREETEXT]
+embedded computer system.
+
+(1) computer system that is part of a larger system and performs some of the requirements of that system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Example: a computer system used in an aircraft or rapid transit system
+
+Note: The hardware and software of an embedded system are usually minimized and optimized for specific functions. The embedded system includes at least one microcontroller, microprocessor or digital signal processor. The embedded system designed to optimize reliability, cost, size and power saving for applications.
+
+Syn: embedded system
+[/FREETEXT]

--- a/docs/glossary/embedded_operating_system.sdoc
+++ b/docs/glossary/embedded_operating_system.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: embedded operating system
+
+[FREETEXT]
+embedded operating system.
+
+(1) operating system software for an embedded computer system (ISO/IEC/IEEE 24765d:2015)
+[/FREETEXT]

--- a/docs/glossary/embedded_software.sdoc
+++ b/docs/glossary/embedded_software.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: embedded software
+
+[FREETEXT]
+embedded software.
+
+(1) software that is part of a larger system and performs some of the requirements of that system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Example: software used in an aircraft or rapid transit system
+[/FREETEXT]

--- a/docs/glossary/index.sdoc
+++ b/docs/glossary/index.sdoc
@@ -102,6 +102,12 @@ FILE: real-time_scheduling_theory.sdoc
 FILE: real-time.sdoc
 
 [DOCUMENT_FROM_FILE]
+FILE: reuse.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: reused_source_statement.sdoc
+
+[DOCUMENT_FROM_FILE]
 FILE: scheduler.sdoc
 
 [DOCUMENT_FROM_FILE]

--- a/docs/glossary/index.sdoc
+++ b/docs/glossary/index.sdoc
@@ -1,0 +1,126 @@
+[DOCUMENT]
+TITLE: Glossary
+
+[FREETEXT]
+TBD
+[/FREETEXT]
+
+[DOCUMENT_FROM_FILE]
+FILE: boot.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: bootstrap.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: central_processing_unit_(CPU).sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: core.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: critical_section.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: deadlock.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: embedded_computer_system.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: embedded_operating_system.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: embedded_software.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: initial_program_loader.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: interrupt_controller.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: interrupt_latency.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: interrupt_request.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: interrupt.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: interrupt_service_routine.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: kernel.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: lockout.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: main_program.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: microcontroller_(unit)_(MCU).sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: microprocessor.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: multi-core.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: multitasking.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: mutual_exclusion.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: operating_system.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: priority_ceiling_protocol.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: priority_interrupt.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: priority_inversion.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: rate-monotonic_algorithm.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: real-time_clock_(RTC).sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: real-time_operating_system_(RTOS).sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: real-time_scheduling_theory.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: real-time.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: scheduler.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: security_kernel.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: semaphore.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: task_priority_criteria.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: task.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: timer_event.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: user.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: Zephyr_RTOS.sdoc

--- a/docs/glossary/initial_program_loader.sdoc
+++ b/docs/glossary/initial_program_loader.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: initial program loader
+
+[FREETEXT]
+initial program loader.
+
+(1) bootstrap loader used to load that part of an operating system needed to load the remainder of the operating system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/interrupt.sdoc
+++ b/docs/glossary/interrupt.sdoc
@@ -1,0 +1,16 @@
+[DOCUMENT]
+TITLE: interrupt
+
+[FREETEXT]
+interrupt.
+
+(1) suspension of a process to handle an event external to the process (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(2) to cause the suspension of a process (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(3) loosely, an interrupt request (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Syn: interruption
+
+See Also: interrupt latency, interrupt mask, interrupt priority, interrupt service routine, priority interrupt
+[/FREETEXT]

--- a/docs/glossary/interrupt_controller.sdoc
+++ b/docs/glossary/interrupt_controller.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: interrupt controller
+
+[FREETEXT]
+interrupt controller.
+
+(1) functional unit (integrated circuit) that determines the source and priority of interrupt requests and manages their execution (ISO/IEC/IEEE 24765d:2015)
+[/FREETEXT]

--- a/docs/glossary/interrupt_latency.sdoc
+++ b/docs/glossary/interrupt_latency.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: interrupt latency
+
+[FREETEXT]
+interrupt latency.
+
+(1) delay between a computer system's receipt of an interrupt request and its handling of the request (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: interrupt priority
+[/FREETEXT]

--- a/docs/glossary/interrupt_request.sdoc
+++ b/docs/glossary/interrupt_request.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: interrupt request
+
+[FREETEXT]
+interrupt latency.
+
+(1) delay between a computer system's receipt of an interrupt request and its handling of the request (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: interrupt priority
+[/FREETEXT]

--- a/docs/glossary/interrupt_service_routine.sdoc
+++ b/docs/glossary/interrupt_service_routine.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: interrupt service routine
+
+[FREETEXT]
+interrupt service routine.
+
+(1) routine that responds to interrupt requests by storing the contents of critical registers, performing the processing required by the interrupt request, restoring the register contents, and restarting the interrupted process (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Syn: ISR
+[/FREETEXT]

--- a/docs/glossary/kernel.sdoc
+++ b/docs/glossary/kernel.sdoc
@@ -1,0 +1,14 @@
+[DOCUMENT]
+TITLE: kernel
+
+[FREETEXT]
+kernel.
+
+(1) that portion of an operating system that is kept in main memory at all times (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(2) a software module that encapsulates an elementary function or functions of a system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Syn: resident control program
+
+See Also: nucleus, supervisory program
+[/FREETEXT]

--- a/docs/glossary/lockout.sdoc
+++ b/docs/glossary/lockout.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: lockout
+
+[FREETEXT]
+lockout.
+
+(1) computer resource allocation technique in which shared resources (especially data) are protected by permitting access by only one device or process at a time (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: deadlock, semaphore
+[/FREETEXT]

--- a/docs/glossary/main_program.sdoc
+++ b/docs/glossary/main_program.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: main program
+
+[FREETEXT]
+main program.
+
+(1) software component that is called by the operating system of a computer and that usually calls other software components (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: routine, subprogram
+[/FREETEXT]

--- a/docs/glossary/microcontroller_(unit)_(MCU).sdoc
+++ b/docs/glossary/microcontroller_(unit)_(MCU).sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: microcontroller (unit) (MCU)
+
+[FREETEXT]
+microcontroller (unit) (MCU).
+
+(1) unit with application control function on a single chip (ISO/IEC/IEEE 24765c:2014)
+
+Note: It contains a processor, RAM, ROM, clock, register, and I/O control unit.
+
+Syn: single chip microcomputer
+[/FREETEXT]

--- a/docs/glossary/microprocessor.sdoc
+++ b/docs/glossary/microprocessor.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: microprocessor
+
+[FREETEXT]
+microprocessor.
+
+(1) processor whose elements have been miniaturized into one or a few integrated circuits (ISO/IEC 2382:2015 Information technology -- Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/multi-core.sdoc
+++ b/docs/glossary/multi-core.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: multi-core
+
+[FREETEXT]
+multi-core.
+
+(1) chip with two or more microprocessor units (ISO/IEC/IEEE 24765e:2015)
+[/FREETEXT]

--- a/docs/glossary/multitasking.sdoc
+++ b/docs/glossary/multitasking.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: multitasking
+
+[FREETEXT]
+multitasking.
+
+(1) mode of operation in which two or more tasks are executed in an interleaved manner (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: multiprocessing, multiprogramming, time sharing
+[/FREETEXT]

--- a/docs/glossary/mutual_exclusion.sdoc
+++ b/docs/glossary/mutual_exclusion.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: mutual exclusion
+
+[FREETEXT]
+mutual exclusion.
+
+(1) giving access to shared data only to one task at a time (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Note: can be enforced by means of binary semaphores or by using monitors.
+[/FREETEXT]

--- a/docs/glossary/operating_system.sdoc
+++ b/docs/glossary/operating_system.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: operating system
+
+[FREETEXT]
+operating system.
+
+(1) collection of software, firmware, and hardware elements that controls the execution of computer programs and provides such services as computer resource allocation, job control, input/output control, and file management in a computer system (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Syn: OS
+[/FREETEXT]

--- a/docs/glossary/priority_ceiling_protocol.sdoc
+++ b/docs/glossary/priority_ceiling_protocol.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: priority ceiling protocol
+
+[FREETEXT]
+priority ceiling protocol.
+
+(1) algorithm that provides bounded priority inversion (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Note: that is, at most one lower-priority task can block a higher-priority task
+[/FREETEXT]

--- a/docs/glossary/priority_interrupt.sdoc
+++ b/docs/glossary/priority_interrupt.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: priority interrupt
+
+[FREETEXT]
+priority interrupt.
+
+(1) interrupt performed to permit execution of a process that has a higher priority than the process currently executing (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/priority_inversion.sdoc
+++ b/docs/glossary/priority_inversion.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: priority inversion
+
+[FREETEXT]
+priority inversion.
+
+(1) case where a task's execution is delayed because a lower priority task is blocking it (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/rate-monotonic_algorithm.sdoc
+++ b/docs/glossary/rate-monotonic_algorithm.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: rate-monotonic algorithm
+
+[FREETEXT]
+rate-monotonic algorithm.
+
+(1) real-time scheduling algorithm that assigns higher priorities to tasks with shorter periods (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/real-time.sdoc
+++ b/docs/glossary/real-time.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: real-time
+
+[FREETEXT]
+real-time.
+
+(1) problem, system, or application that is concurrent and has timing constraints whereby incoming events must be processed within a given timeframe (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+(2) pertaining to a system or mode of operation in which computation is performed during the actual time that an external process occurs, in order that the computation results can be used to control, monitor, or respond in a timely manner to the external process (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Syn: realtime, real time
+[/FREETEXT]

--- a/docs/glossary/real-time_clock_(RTC).sdoc
+++ b/docs/glossary/real-time_clock_(RTC).sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: real-time clock (RTC)
+
+[FREETEXT]
+real-time clock (RTC).
+
+(1) integrated circuit that tracks the current time in human units (ISO/IEC/IEEE 24765d:2015)
+
+Syn: real time clock
+[/FREETEXT]

--- a/docs/glossary/real-time_operating_system_(RTOS).sdoc
+++ b/docs/glossary/real-time_operating_system_(RTOS).sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: real-time operating system (RTOS)
+
+[FREETEXT]
+real-time operating system (RTOS).
+
+(1) operating system intended to handle transaction requests immediately upon receipt (ISO/IEC/IEEE 24765c:2014)
+[/FREETEXT]

--- a/docs/glossary/real-time_scheduling_theory.sdoc
+++ b/docs/glossary/real-time_scheduling_theory.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: real-time scheduling theory
+
+[FREETEXT]
+real-time scheduling theory.
+
+(1) theory for priority-based scheduling of concurrent tasks with hard deadlines (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+Note: It addresses how to determine whether a group of tasks, whose individual CPU utilization is known, will meet their deadlines.
+[/FREETEXT]

--- a/docs/glossary/reuse.sdoc
+++ b/docs/glossary/reuse.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: reuse
+
+[FREETEXT]
+reuse.
+
+(1) use of an asset in the solution of different problems (IEEE 1517-2010 IEEE Standard for Information Technology--System and software life cycle processes--Reuse processes, 3) (ISO/IEC/IEEE 24765j:2021)
+
+(2) building a software system at least partly from existing pieces to perform a new application (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/reused_source_statement.sdoc
+++ b/docs/glossary/reused_source_statement.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: reused source statement
+
+[FREETEXT]
+reused source statement.
+
+(1) unmodified source statement obtained for the product from an external source (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/scheduler.sdoc
+++ b/docs/glossary/scheduler.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: scheduler
+
+[FREETEXT]
+scheduler.
+
+(1) computer program, usually part of an operating system, that schedules, initiates, and terminates jobs (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/security_kernel.sdoc
+++ b/docs/glossary/security_kernel.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: security kernel
+
+[FREETEXT]
+security kernel.
+
+(1) small, self-contained collection of key security-related statements that works as a privileged part of an operating system, specifying and enforcing criteria that must be met for programs and data to be accessed (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/semaphore.sdoc
+++ b/docs/glossary/semaphore.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: semaphore
+
+[FREETEXT]
+semaphore.
+
+(1) shared variable used to synchronize concurrent processes by indicating whether an action has been completed or an event has occurred (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+
+See Also: flag, indicator
+[/FREETEXT]

--- a/docs/glossary/task.sdoc
+++ b/docs/glossary/task.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: task
+
+[FREETEXT]
+task. ... 
+
+(2) in software design, a software component that can operate in parallel with other software components (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary) ... 
+[/FREETEXT]

--- a/docs/glossary/task_priority_criteria.sdoc
+++ b/docs/glossary/task_priority_criteria.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: task priority criteria
+
+[FREETEXT]
+task priority criteria.
+
+(1) category of the task-structuring criteria addressing the relative importance of executing a given task (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/timer_event.sdoc
+++ b/docs/glossary/timer_event.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: timer event
+
+[FREETEXT]
+timer event.
+
+(1) stimulus used to periodically activate a task (ISO/IEC/IEEE 24765:2017 Systems and software engineering-Vocabulary)
+[/FREETEXT]

--- a/docs/glossary/user.sdoc
+++ b/docs/glossary/user.sdoc
@@ -1,0 +1,35 @@
+[DOCUMENT]
+TITLE: user
+
+[FREETEXT]
+user.
+
+(1) individual or group that interacts with a system or benefits from a system during its utilization (ISO/IEC/IEEE 12207:2017 Systems and software engineering--Software life cycle processes, 3.1.70) (ISO/IEC/IEEE 15939:2017 Systems and software engineering--Measurement process, 3.40) (ISO/IEC 25010:2011 Systems and software engineering--Systems and software Quality Requirements and Evaluation (SQuaRE)--System and software quality models, 4.3.16) (ISO/IEC/IEEE 15288:2023 Systems and software engineering--System life cycle processes, 3.53) (ISO/IEC/IEEE 24748-1:2018 Systems and software engineering--Life cycle management--Part 1: Guidelines for life cycle management, 3.60)
+
+(2) person who interacts with a system, product or service (ISO/IEC 25064:2013 Systems and software engineering--Software product Quality Requirements and Evaluation (SQuaRE)--Common Industry Format (CIF) for usability: User needs report, 4.17)
+
+(3) the person (or persons) who operates or interacts directly with a software-intensive system
+
+(4) any person or thing that communicates or interacts with the software at any time (ISO/IEC 19761:2011 Software engineering -- COSMIC: a functional size measurement method, 2.27) (ISO/IEC 20926:2009 Software and systems engineering -- Software measurement -- IFPUG functional size measurement method 2009, 3.50) (ISO/IEC 24570:2018 Software engineering -- NESMA functional size measurement method -- Definitions and counting guidelines for the application of function point analysis, B) (ISO/IEC 14143-1:2007 Information technology--Software measurement--Functional size measurement; Part 1: Definition of concepts) (ISO/IEC 29881:2010 Information technology--Software and systems engineering--FiSMA 1.1 functional size measurement method, 3.9)
+
+(5) individual or group that benefits from a system during its utilization (ISO/IEC 25022:2016, Systems and software engineering -- Systems and software quality requirements and evaluation (SQuaRE) -- Measurement of quality in use, 4.26)
+
+(6) person who performs one or more tasks with an automated system; a member of a specific audience (ISO/IEC/IEEE 26512:2018 Systems and software engineering--Requirements for acquirers and suppliers of information for users, 3.25)
+(7) person (or instance) who uses the functions of a CBSS via a terminal (or an equivalent machine-user-interface) by submitting tasks and receiving the computed results (ISO/IEC 14756:1999 Information technology -- Measurement and rating of performance of computer-based software systems, 4.31)
+(8) individual or group that benefits from a ready to use software product during its utilization (ISO/IEC 25051:2014 Software engineering -- Software product Quality Requirements and Evaluation (SQuaRE) -- Requirements for quality of Ready to Use Software Product (RUSP) and instructions for testing, 4.1.26)
+
+(9) individual or organization that uses the system or software to perform a specific function (ISO/IEC 25000:2014 Systems and software Engineering--Systems and software product Quality Requirements and Evaluation (SQuaRE) -- Guide to SQuaRE, 4.40)
+
+(10) individual who or group that benefits from a system during its utilization (INCOSE Systems Engineering Handbook, 5th ed.)
+
+(11) person who interacts with an autonomous/intelligent system (IEEE 7010-2020, IEEE Recommended Practice for Assessing the Impact of Autonomous and Intelligent Systems on Human Well-Being, 2.1)
+
+(12) person who interacts with the product (IEC/IEEE 82079-1:2019 Preparation of information for use (instructions for use) of products: Part 1: Principles and general requirements, 3.47)
+
+Example: operators, recipients of the results of operating the system or software; a bank customer who visits a branch, receives a paper statement, or carries out telephone banking using a call center
+
+Note: User can include persons who install, operate, service, maintain, or dispose of the product. The user can perform other roles, such as acquirer or maintainer. The role of user and the role of operator can be vested, simultaneously or sequentially, in the same individual or organization.
+
+See Also: developer, end user, functional user, indirect user, operator, secondary user
+
+[/FREETEXT]


### PR DESCRIPTION
Created glossary document skeleton with fragments for each term.

Add relevant terms from SEVOCAB (https://pascal.computer.org), which is a collection of authoritative definitions for software and systems engineering terms (from ISO/IEC/IEEE standards).

Add entry for "Zephyr RTOS" with a definition of TBD.

Verifed by:

1. Visual verification of strictdoc server web page using firefox.