### PR TITLE
cleanup: Remove grammer field review comments

### DIFF
--- a/docs/software_requirements/c_library.sdoc
+++ b/docs/software_requirements/c_library.sdoc
@@ -113,9 +113,6 @@ The Zephyr RTOS shall support a file i/O based interface for driver communicatio
 USER_STORY: >>>
 As a Zephyr RTOS user, I want to be able to use File I/O functions.
 <<<
-REVIEW_COMMENT: >>>
-A wrong C header seems to be included: stdint.h does not have to do with I/O.
-<<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-2

--- a/docs/software_requirements/device_driver_api.sdoc
+++ b/docs/software_requirements/device_driver_api.sdoc
@@ -16,11 +16,6 @@ The Zephyr RTOS shall provide abstraction of device drivers with common function
 
 Proposal for replacement: Zephyr shall provide an interface between application and individual device drivers to provide an abstraction of device drivers with common functionalities.
 <<<
-REVIEW_COMMENT: >>>
-What are common functionalities?
-
-Clarification: Abstract API drivers, UART. Set of files associated with that. Include drivers. 50+ files. Best place to look at is the documentation (not the files).
-<<<
 
 [REQUIREMENT]
 UID: ZEP-46
@@ -33,9 +28,4 @@ The Zephyr RTOS shall provide an interface for managing a defined set of hardwar
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want hardware exceptions (hardware failures, programming mistakes) to be handled gracefully (no program crashes as far as possible).
-<<<
-REVIEW_COMMENT: >>>
-What does "system" mean in this context? Architecture?
-
-NP: Now I think system means HW platform.
 <<<

--- a/docs/software_requirements/hw_arch_interface.sdoc
+++ b/docs/software_requirements/hw_arch_interface.sdoc
@@ -66,11 +66,6 @@ USER_STORY: >>>
 If MCU power state was meant here:
 As a Zephyr RTOS user I want to control the MCU's power saving mode such e.g. operation, sleep, deep sleep or similar as supported by the selected MCU.
 <<<
-REVIEW_COMMENT: >>>
-What is life cycle - power on, standby, power off?  or ????
-
-Clarification: Starting and Stopping, and putting it into Stand-By Mode (whatever the processor supports)
-<<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-1

--- a/docs/software_requirements/logging.sdoc
+++ b/docs/software_requirements/logging.sdoc
@@ -43,9 +43,6 @@ The Zephyr RTOS logging shall support formatting of log messages to enable filte
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able my application to format texts (printf alike) into the log message.
 <<<
-REVIEW_COMMENT: >>>
-Question: formatting in which way? length, colour, tags, etc?
-<<<
 
 [REQUIREMENT]
 UID: ZEP-66
@@ -59,9 +56,6 @@ The Zephyr RTOS logging system shall support filtering based on severity level.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to distinguish between different severity level for my log messages (e.g. DEBUG, INFO, WARN, ERROR, PANIC).
 <<<
-REVIEW_COMMENT: >>>
-Question: Filtering during runtime or a kconfig option to initially set the filter for logging
-<<<
 
 [REQUIREMENT]
 UID: ZEP-67
@@ -74,9 +68,6 @@ The Zephyr RTOS shall support logging messages to multiple system resources.
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to simultaneously log to different channels which may store / redirect the information on / to different hardware (EEPROM, Flash, FRAM, UART, Ethernet, USB etc.).
-<<<
-REVIEW_COMMENT: >>>
-Question: What kind of backends shall be supported? More than one at a time?   Word choices.... backends/devices/channels/destinations/resources (devices, memory, ....) )
 <<<
 
 [REQUIREMENT]

--- a/docs/software_requirements/memory_objects.sdoc
+++ b/docs/software_requirements/memory_objects.sdoc
@@ -17,9 +17,6 @@ The Zephyr RTOS shall allow threads to dynamically allocate variable-sized memor
 USER_STORY: >>>
 As a Zephyr RTOS user I want my application to be able to dynamically allocate memory of a application defined size.
 <<<
-REVIEW_COMMENT: >>>
-Is dynamic memory allocation only allowed in memory pool objects?
-<<<
 
 [REQUIREMENT]
 UID: ZEP-88

--- a/docs/software_requirements/memory_protection.sdoc
+++ b/docs/software_requirements/memory_protection.sdoc
@@ -17,9 +17,6 @@ The Zephyr RTOS shall support memory protection features to isolate a thread's m
 USER_STORY: >>>
 As a Zephyr RTOS user I want memory to be allocated and protected to my application threads preventing mistakenly access to foreign memory as far as the hardware allows.
 <<<
-REVIEW_COMMENT: >>>
-Functional it is memory management, but it also strongly relates to the architecture abstraction and memory access
-<<<
 
 [REQUIREMENT]
 UID: ZEP-70
@@ -32,9 +29,6 @@ The Zephyr RTOS shall provide a mechanism to grant user threads access to kernel
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want, from the user space, under certain conditions, access to kernel objects.
-<<<
-REVIEW_COMMENT: >>>
-What are the conditions to a user thread to get access to a kernel object?
 <<<
 
 [REQUIREMENT]
@@ -61,9 +55,6 @@ The Zephyr RTOS shall have a defined behaviour when an invocation of an unimplem
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want Zephyr OS to indicate any unimplemented system call by an appropriate error message.
-<<<
-REVIEW_COMMENT: >>>
-What is an "unimplemented system call"? An empty system call function? Can I call something that is not there it all? Isn't this more a topic for security? - makes sense to handle this from the safety perspective, but still raises some questions here.
 <<<
 
 [REQUIREMENT]
@@ -153,9 +144,6 @@ The Zephyr RTOS shall support a defined mechanism for user mode handling a of de
 USER_STORY: >>>
 As a Zephyr RTOS user I want, when a stack overflow is detected, to be able to implement a graceful, application defined handling of the exception.
 <<<
-REVIEW_COMMENT: >>>
-Need for handlers and callbacks outside of thread.   Need to be able to answer "Can the safety application rely on Zephyr to reach the safe state after stack overflow occurred?"   Can it handle degraded mode.
-<<<
 
 [REQUIREMENT]
 UID: ZEP-80
@@ -169,9 +157,6 @@ The Zephyr RTOS shall support detection of stack overflows.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to get an indication when a stack overflow occurs at least during debugging / the development phase, and for safety applications also in a release version of my application.
 <<<
-REVIEW_COMMENT: >>>
-RS: IMHO should be configurable due the to performance penalty introduced with it.   - DL:  THere are various modes,  canaries, and they can be turned off.  KS:  Clearly safety & security mechanism.
-<<<
 
 [REQUIREMENT]
 UID: ZEP-81
@@ -181,9 +166,6 @@ COMPONENT: Memory Protection
 TITLE: Boot Time Memory Access Policy
 STATEMENT: >>>
 The Zephyr RTOS shall support configurable access to memory during boot time.
-<<<
-REVIEW_COMMENT: >>>
-What does "policy" mean in this context? Does this mean to choose between different start up sequences?
 <<<
 
 [REQUIREMENT]
@@ -197,9 +179,6 @@ The Zephyr RTOS shall provide helper functions for system call handler functions
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want Zepyhr OS to validate system call parameters passed from the user mode to the kernel mode to avoid crashes and undefined behaviour.
-<<<
-REVIEW_COMMENT: >>>
-I do not understand that. What kind of helper functions? Kind of plausibility checks? Does it make sense to provide this functionality on OS level?   David:  These are likely just validation that the parameters are not going to be dangerous (security/safety).
 <<<
 
 [REQUIREMENT]
@@ -219,9 +198,6 @@ e.g.
 - verify the string length is smaller or equal to the syscalls defined max.
 - verify that the length type does not overflow when allocating one more byte ???
 <<<
-REVIEW_COMMENT: >>>
-Is this a helper function like mentioned in ZEP133? What does C string mean here? Like a string variable that's passed down from user mode to ??? by a system call?
-<<<
 
 [REQUIREMENT]
 UID: ZEP-84
@@ -233,9 +209,6 @@ STATEMENT: >>>
 The Zephyr RTOS shall track kernel objects that are used by user mode threads.
 
 Note: this means Zephyr shall track the resources used by the user mode thread (associate this with a user story).
-<<<
-REVIEW_COMMENT: >>>
-Does this mean that the user mode threads are monitored wrt to their usage of kernel objects?  Example/User story would help.
 <<<
 
 [REQUIREMENT]
@@ -262,7 +235,4 @@ The Zephyr RTOS shall support assigning a memory pool to act as that thread's re
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able, during runtime from the kernel, to request a memory area/pool which is exclusively available to the requesting thread protected against access from other threads.
-<<<
-REVIEW_COMMENT: >>>
-What is the difference to ZEP 136? Read & Write, while ZEP136 is just read?
 <<<

--- a/docs/software_requirements/mutex.sdoc
+++ b/docs/software_requirements/mutex.sdoc
@@ -20,6 +20,3 @@ As a Zephyr RTOS user I want to be able to sychonize threads when accessing comm
 - immediately return with a negative message if the resource is not available and allow the thread to continue.
 - wait for a given time for the resource to become available or return with a negative message.
 <<<
-REVIEW_COMMENT: >>>
-Concern over phrase recursive.  What is it MUTEXing? Memory Management?
-<<<

--- a/docs/software_requirements/software_requirements.sgra
+++ b/docs/software_requirements/software_requirements.sgra
@@ -23,8 +23,5 @@ ELEMENTS:
   - TITLE: USER_STORY
     TYPE: String
     REQUIRED: False
-  - TITLE: REVIEW_COMMENT
-    TYPE: String
-    REQUIRED: False
   RELATIONS:
   - TYPE: Parent

--- a/docs/software_requirements/thread_scheduling.sdoc
+++ b/docs/software_requirements/thread_scheduling.sdoc
@@ -103,9 +103,6 @@ The Zephyr RTOS shall provide an interface for running user-supplied functions.
 USER_STORY: >>>
 As a Zephyr RTOS user, I want to be able to run functions in-order in a separated thread/threads.
 <<<
-REVIEW_COMMENT: >>>
-Where do we put this,  thread, scheduling or???
-<<<
 
 [REQUIREMENT]
 UID: ZEP-116
@@ -118,9 +115,6 @@ The Zephyr RTOS shall organize running threads into a fixed list of numeric prio
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user, I want that the OS organize running threads in a fixed list of numeric priorities.
-<<<
-REVIEW_COMMENT: >>>
-The Zephyr RTOS shall allow prioritizing threads
 <<<
 
 [REQUIREMENT]
@@ -160,9 +154,6 @@ The Zephyr RTOS shall support time sharing of CPU resources among threads of the
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user, I want to be able to configure my RTOS in the way, that the CPU resources are shared evenly among executed threads of the same priority.
-<<<
-REVIEW_COMMENT: >>>
-what does traditional mean here?   Round robin?
 <<<
 
 [/SECTION]

--- a/docs/software_requirements/tracing.sdoc
+++ b/docs/software_requirements/tracing.sdoc
@@ -57,9 +57,6 @@ Zephyr shall provide an interface to identify the objects being traced.
 USER_STORY: >>>
 As a Zepyhr OS user, I want to be able to give each object which I create a name / label in order to be able to identify them in a trace log.
 <<<
-REVIEW_COMMENT: >>>
-What objects?   hardware devices, code, ....
-<<<
 
 [REQUIREMENT]
 UID: ZEP-34
@@ -72,7 +69,4 @@ Zepyhr shall prevent the tracing functionality from interfering with normal oper
 <<<
 USER_STORY: >>>
 As a Zepyhr OS user, I want that the trace functionality do not interfere or slow down the operation system functionality.
-<<<
-REVIEW_COMMENT: >>>
-What are "normal" operations? Might make sense to rephrase this to "any other operation"
 <<<

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -30,9 +30,6 @@ The Zephyr RTOS shall support symmetric multiprocessing on multiple cores.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to use Zephyr OS on multi core (SMP-)MCUs/MPUs.
 <<<
-REVIEW_COMMENT: >>>
-From the Docs: No special application code needs to be written to take advantage of this feature
-<<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-1
@@ -61,9 +58,6 @@ The Zephyr RTOS shall provide a framework for managing device drivers and periph
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want my application to be portable between different MCU architectures (ARM Cortex-M/A, Intel x86, RISCV etc.) and MCU vendors (STM, NXP, Intel, etc.) without having to change the MCU peripherals access.
-<<<
-REVIEW_COMMENT: >>>
-TBD: Title seems to need refinement. Also, this requirement's user story seems to be identical to that of ZEP-1.
 <<<
 
 [REQUIREMENT]
@@ -116,9 +110,6 @@ The Zephyr RTOS shall provide a framework for logging events.
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to log application defined events as well as framework exceptions.
-<<<
-REVIEW_COMMENT: >>>
-Nicole: TBD: we need to have logging in the safety scope?
 <<<
 
 [REQUIREMENT]
@@ -234,9 +225,6 @@ The Zephyr RTOS shall provide a framework for managing multiple threads of execu
 USER_STORY: >>>
 As a Zephyr RTOS user, I want to be able to manage the execute of multiple threads with different priorities.
 <<<
-REVIEW_COMMENT: >>>
-TBD: Nothing about priorities...
-<<<
 
 [REQUIREMENT]
 UID: ZEP-122
@@ -277,7 +265,4 @@ Zepyhr shall provide a framework mechanism for tracing low level system operatio
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user, I want to be able to trace different OS operations.
-<<<
-REVIEW_COMMENT: >>>
-TBD: What are low level system operations in this context?
 <<<

--- a/docs/system_requirements/system_requirements.sgra
+++ b/docs/system_requirements/system_requirements.sgra
@@ -23,8 +23,5 @@ ELEMENTS:
   - TITLE: USER_STORY
     TYPE: String
     REQUIRED: False
-  - TITLE: REVIEW_COMMENT
-    TYPE: String
-    REQUIRED: False
   RELATIONS:
   - TYPE: Parent


### PR DESCRIPTION
Remove the support of the requirements file field
"review_comments".
This field was a leftover of the initial import of
the excel sheet.