### PR TITLE
General: Remove required status from UID field

### DIFF
--- a/docs/software_requirements/software_requirements.sgra
+++ b/docs/software_requirements/software_requirements.sgra
@@ -4,7 +4,7 @@ ELEMENTS:
   FIELDS:
   - TITLE: UID
     TYPE: String
-    REQUIRED: True
+    REQUIRED: False
   - TITLE: STATUS
     TYPE: String
     REQUIRED: True

--- a/docs/system_requirements/system_requirements.sgra
+++ b/docs/system_requirements/system_requirements.sgra
@@ -4,7 +4,7 @@ ELEMENTS:
   FIELDS:
   - TITLE: UID
     TYPE: String
-    REQUIRED: True
+    REQUIRED: False
   - TITLE: STATUS
     TYPE: String
     REQUIRED: True


### PR DESCRIPTION
Remove the required status from the UID filed,
because this leads to an error with the command
manage auto-uid, which is used to generated UIDs
for new requierements.