### PR TITLE
deploy generated docs to GH pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up virtualenv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,21 @@ on:
 
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
+  # Build job
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -20,8 +31,27 @@ jobs:
             python3 -m venv ./venv/
             source ./venv/bin/activate
             pip install -r requirements.txt
-      
+
       - name: Check with StrictDoc
+        id: build
         run: |
             source ./venv/bin/activate
-            strictdoc export .
+            strictdoc export . --included-documents
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./output/html
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This repository contains a preliminary work on the Zephyr Project requirements.
 The requirements are captured using
 [StrictDoc](https://github.com/strictdoc-project/strictdoc).
 
+## Deployed Documentation
+
+The requirements documentation is available online at:
+[https://zephyrproject-rtos.github.io/reqmgmt](https://zephyrproject-rtos.github.io/reqmgmt)
+
 ## System requirements
 
 The requirements shall be browsable and editable on all major operating systems


### PR DESCRIPTION
Make the req docs built using `strictdoc export` available at https://zephyrproject-rtos.github.io/reqmgmt

example of this PR running on my own fork: https://kartben.github.io/reqmgmt/
