### PR TITLE
arch: add system architecture decomposition with mailbox worked example

### DIFF
--- a/docs/software_architecture/mailboxes.sdoc
+++ b/docs/software_architecture/mailboxes.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Mailboxes — Software Architecture
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_architecture.sgra
+
+[TEXT]
+STATEMENT: >>>
+SPDX-License-Identifier: Apache-2.0
+<<<
+
+[COMPONENT]
+UID: ZEP-SWARCH-MBOX
+STATUS: Draft
+COMPONENT: Mailboxes
+TITLE: Mailbox Software Architecture
+STATEMENT: >>>
+Software architecture for the mailbox subsystem.
+
+Design documentation:
+`Mailboxes <https://docs.zephyrproject.org/latest/kernel/services/data_passing/mailboxes.html>`_
+
+API reference:
+`Mailbox APIs <https://docs.zephyrproject.org/latest/doxygen/html/group__mailbox__apis.html>`_
+
+Kernel source: kernel/mailbox.c
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYSARCH-MBOX

--- a/docs/software_architecture/software_architecture.sgra
+++ b/docs/software_architecture/software_architecture.sgra
@@ -1,0 +1,42 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: COMPONENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: True
+  - TITLE: COMPONENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent

--- a/docs/software_requirements/mailboxes.sdoc
+++ b/docs/software_requirements/mailboxes.sdoc
@@ -24,7 +24,7 @@ As a Zephyr RTOS developer, I want to be able to initialize a mailbox instance s
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-2
@@ -40,7 +40,7 @@ As a Zephyr RTOS developer, I want to be able to statically define and initializ
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-3
@@ -56,7 +56,7 @@ As a Zephyr RTOS developer, I want to be able to send messages of different size
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-4
@@ -69,7 +69,7 @@ The Zephyr RTOS shall handle the data transfer between mailbox objects of the se
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-5
@@ -85,7 +85,7 @@ As a Zephyr RTOS developer, I want to be able to send a message and wait for it 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-6
@@ -101,7 +101,7 @@ As a Zephyr RTOS developer, I want to be able to limit how long my thread waits 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-7
@@ -117,7 +117,7 @@ As a Zephyr RTOS developer, I want to be able to send a message without waiting 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-8
@@ -133,7 +133,7 @@ As a Zephyr RTOS developer, I want to be notified when my asynchronously sent me
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-9
@@ -149,7 +149,7 @@ As a Zephyr RTOS developer, I want to be able to receive messages from other thr
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-10
@@ -165,7 +165,7 @@ As a Zephyr RTOS developer, I want to be able to extract message data into my bu
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-11
@@ -178,7 +178,7 @@ When a receiving thread requests a message via a mailbox object and no message i
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-12
@@ -194,7 +194,7 @@ As a Zephyr RTOS developer, I want to be able to limit how long my thread waits 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-13
@@ -210,7 +210,7 @@ As a Zephyr RTOS developer, I want to be able to identify the source or destinat
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-14
@@ -226,7 +226,7 @@ As a Zephyr RTOS developer, I want message delivery to respect thread priorities
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-15
@@ -239,7 +239,7 @@ When multiple threads of equal priority are waiting on an empty mailbox object, 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-16
@@ -255,7 +255,7 @@ As a Zephyr RTOS developer, I want to be able to create as many mailboxes as my 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX
 
 [REQUIREMENT]
 UID: ZEP-SRS-25-17
@@ -271,4 +271,4 @@ As a Zephyr RTOS developer, I want the system to validate my inputs and return e
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-25
+  VALUE: ZEP-SWARCH-MBOX

--- a/docs/system_architecture/system_architecture.sdoc
+++ b/docs/system_architecture/system_architecture.sdoc
@@ -1,0 +1,80 @@
+[DOCUMENT]
+TITLE: Zephyr RTOS — System Architecture
+REQ_PREFIX: ZEP-SYSARCH-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: system_architecture.sgra
+
+[TEXT]
+STATEMENT: >>>
+SPDX-License-Identifier: Apache-2.0
+
+This document defines the architectural decomposition of the Zephyr RTOS.
+It identifies the major subsystems of the RTOS and establishes traceable
+architectural nodes that link system requirements (ZEP-SYRS) to software
+requirements (ZEP-SRS).
+
+The initial scope of safety work is the Kernel subsystem. Other
+subsystems (networking, Bluetooth, etc.) will be added as safety
+certification scope expands.
+<<<
+
+[[SECTION]]
+TITLE: Kernel
+
+[TEXT]
+STATEMENT: >>>
+The kernel provides the core runtime: threading, scheduling, synchronization,
+data passing, memory management, timing, and device driver infrastructure.
+
+The decomposition below mirrors the Zephyr kernel documentation structure
+(doc/kernel/) as the authoritative design reference.
+<<<
+
+[[SECTION]]
+TITLE: Data Passing
+
+[TEXT]
+STATEMENT: >>>
+Kernel objects for passing data between threads and ISRs.
+
+`Kernel Services <https://docs.zephyrproject.org/latest/kernel/services/index.html>`_
+<<<
+
+[[SECTION]]
+TITLE: Mailboxes
+
+[TEXT]
+STATEMENT: >>>
+Enhanced message passing allowing threads to exchange messages of any size
+synchronously or asynchronously. Supports non-anonymous messaging, thread
+compatibility filtering, and deferred data retrieval.
+
+`Mailboxes <https://docs.zephyrproject.org/latest/kernel/services/data_passing/mailboxes.html>`_
+<<<
+
+[COMPONENT]
+UID: ZEP-SYSARCH-MBOX
+STATUS: Draft
+COMPONENT: Mailboxes
+TITLE: Mailbox Subsystem
+STATEMENT: >>>
+The kernel shall provide a mailbox subsystem that enables point-to-point
+message exchange between threads, supporting both synchronous and
+asynchronous send operations, with priority-ordered send and receive queues.
+<<<
+RATIONALE: >>>
+Mailboxes extend the data passing capabilities beyond message queues by
+supporting variable-size messages, non-anonymous thread identification,
+and deferred data retrieval. These properties are needed when the sender
+and receiver must coordinate on message content and identity.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-25
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/docs/system_architecture/system_architecture.sgra
+++ b/docs/system_architecture/system_architecture.sgra
@@ -1,0 +1,42 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: COMPONENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: True
+  - TITLE: COMPONENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent


### PR DESCRIPTION
## Summary

Adds an architectural decomposition layer to the requirements tree, using Mailboxes as the worked example of a complete traceability chain. I chose Mailboxes because I submitted and reviewed the full requirements set (PR #83), making it a known-good baseline for demonstrating the concept.

### New artifacts

- `docs/system_architecture/system_architecture.sdoc` — System architecture for the Mailbox path (Kernel → Data Passing → Mailboxes), with a COMPONENT node tracing to the system requirement.
- `docs/system_architecture/system_architecture.sgra` — shared grammar introducing the COMPONENT element type for architectural decomposition, distinct from REQUIREMENT.
- `docs/software_architecture/mailboxes.sdoc` — Software architecture COMPONENT node mapping to existing Zephyr design documentation and API reference.
- `docs/software_architecture/software_architecture.sgra` — shared grammar with COMPONENT element.

### COMPONENT element type

Introduces COMPONENT as a new grammar element for architectural nodes. COMPONENT is semantically distinct from REQUIREMENT — it represents a decomposition node in the architecture, not a testable "shall" statement. Both architecture layers use COMPONENT nodes with Parent relations to participate in the traceability chain.

### Traceability model

Four-layer single-point traceability through the mailbox path:

```
ZEP-SYRS-25          (REQUIREMENT — system requirement)
  ↑ Parent
ZEP-SYSARCH-MBOX     (COMPONENT — system architecture)
  ↑ Parent
ZEP-SWARCH-MBOX      (COMPONENT — software architecture)
  ↑ Parent
ZEP-SRS-25-*         (REQUIREMENT — software requirements)
```

Each layer traces only to its immediate parent — no skip-level tracing.

### Software architecture role

Software architecture documents are mapping layers that point to existing Zephyr documentation rather than duplicating content. The COMPONENT node carries references to the authoritative design docs and API reference.

### Changes to existing artifacts

- Mailbox software requirements (`docs/software_requirements/mailboxes.sdoc`): re-parented from `ZEP-SYRS-25` to `ZEP-SWARCH-MBOX` for single-point traceability through both architecture layers.

## Next steps

Once the pattern is accepted, a follow-up PR would extend the system architecture to cover all kernel subsystems and establish the organizational framework for ongoing requirements work.
