### PR TITLE
reqmgmt: Add Kernel Version requirements (Issue #119 initial slice)

### DIFF
--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -81,3 +81,6 @@ FILE: fifos.sdoc
 
 [DOCUMENT_FROM_FILE]
 FILE: mailboxes.sdoc
+
+[DOCUMENT_FROM_FILE]
+FILE: version.sdoc

--- a/docs/software_requirements/version.sdoc
+++ b/docs/software_requirements/version.sdoc
@@ -1,0 +1,37 @@
+[DOCUMENT]
+TITLE: Kernel Version
+REQ_PREFIX: ZEP-SRS-26-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[TEXT]
+STATEMENT: >>>
+SPDX-License-Identifier: Apache-2.0
+<<<
+
+[REQUIREMENT]
+UID: ZEP-SRS-26-1
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Kernel Version
+TITLE: Kernel version information retrieval
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to retrieve the kernel version information for the present build.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-26
+
+[REQUIREMENT]
+UID: ZEP-SRS-26-2
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Kernel Version
+TITLE: Kernel version element extraction
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to obtain the major, minor, and patch level elements of the kernel version information for the present build.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-26

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -368,3 +368,18 @@ The Zephyr RTOS shall provide a framework to pass messages of arbitrary size bet
 <<<
 
 [[/SECTION]]
+
+[[SECTION]]
+TITLE: Kernel Version
+
+[REQUIREMENT]
+UID: ZEP-SYRS-26
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Kernel Version
+TITLE: Kernel version information
+STATEMENT: >>>
+The Zephyr RTOS shall provide kernel version information for the present build.
+<<<
+
+[[/SECTION]]


### PR DESCRIPTION
Add an initial narrow slice of Kernel Version requirements in support of #119.

**Changes:**
- `docs/system_requirements/index.sdoc`: Add ZEP-SYRS-26 — system-level parent for kernel version information
- `docs/software_requirements/version.sdoc`: Add ZEP-SRS-26-1 (retrieval) and ZEP-SRS-26-2 (element access)
- `docs/software_requirements/index.sdoc`: Register `version.sdoc`

**Scope note:**
This PR intentionally covers retrieval and major/minor/patch element access only.
Broader version or release policy requirements are out of scope.
The component name `Kernel Version` is used to distinguish this topic from release policy concerns;
open to renaming if the maintainers prefer `Version` or `Build Version`.

**Methodology note (first trial):**
This contribution is a trial of an AI-assisted requirements engineering workflow:
- Prior merged PRs were analyzed using AI to study contribution patterns and review tendencies in this repository.
- Requirement drafts were independently produced by two AI agents (Claude Code and Codex) and cross-reviewed between them before being submitted here.
- The workflow itself — using AI not only to write requirements but to analyze past PRs and perform multi-agent review — is offered as a sample approach for the community to evaluate.

Feedback on both the requirements and the AI-assisted process is welcome.

