### PR TITLE
requirements: add missing parent links for traceability

### DIFF
--- a/docs/software_requirements/device_driver_api.sdoc
+++ b/docs/software_requirements/device_driver_api.sdoc
@@ -21,6 +21,9 @@ The Zephyr RTOS shall provide abstraction of device drivers with common function
 
 Proposal for replacement: Zephyr shall provide an interface between application and individual device drivers to provide an abstraction of device drivers with common functionalities.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
 
 [REQUIREMENT]
 UID: ZEP-SRS-14-2
@@ -34,3 +37,6 @@ The Zephyr RTOS shall provide an interface for managing a defined set of hardwar
 USER_STORY: >>>
 As a Zephyr RTOS user I want hardware exceptions (hardware failures, programming mistakes) to be handled gracefully (no program crashes as far as possible).
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4

--- a/docs/software_requirements/exception_and_error_handling.sdoc
+++ b/docs/software_requirements/exception_and_error_handling.sdoc
@@ -22,6 +22,9 @@ The Zephyr RTOS shall provide default handlers for exceptions.
 USER_STORY: >>>
 As a Zephyr RTOS user I want exceptions which I did not handle explicitly (by mistake or on purpose) to be caught by a default handler, defined either by Zephyr OS or by myself.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
 
 [REQUIREMENT]
 UID: ZEP-SRS-16-2
@@ -32,6 +35,9 @@ TITLE: Default handler for fatal errors
 STATEMENT: >>>
 The Zephyr RTOS shall provide default handlers for fatal errors that do not have a dedicated handler.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
 
 [REQUIREMENT]
 UID: ZEP-SRS-16-3
@@ -42,6 +48,9 @@ TITLE: Assigning a specific handler
 STATEMENT: >>>
 The Zephyr RTOS shall provide an interface to assign a specific handler with an exception.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
 
 [REQUIREMENT]
 UID: ZEP-SRS-16-4
@@ -52,3 +61,6 @@ TITLE: Assigning a specific handler (2)
 STATEMENT: >>>
 The Zephyr RTOS shall provide an interface to assign a specific handler for a fatal error.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5

--- a/docs/software_requirements/file_system.sdoc
+++ b/docs/software_requirements/file_system.sdoc
@@ -22,6 +22,9 @@ Zephyr shall provide file create capabilities for files on the file system.
 USER_STORY: >>>
 As a Zephyr OS user I want to be able to create a new file or overwrite an existing file at the same filesystem location / identifier (e.g. path + name).
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-2
@@ -36,6 +39,9 @@ USER_STORY: >>>
 As a Zephyr OS user I want to be able to open a file for writing or reading.
 When opened for writing, I want to have exclusive access to the file.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-3
@@ -49,6 +55,9 @@ Zephyr shall provide read access to files in the file system.
 USER_STORY: >>>
 As a Zephyr OS user I want to be able to read from an existing file, also while the file is read from multiple and write accessed from one other instances.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-4
@@ -62,6 +71,9 @@ Zephyr shall provide write access to the files in the file system.
 USER_STORY: >>>
 As a Zephyr OS user I want to be able to write to a file either from the beginning of the file or appending at the end.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-5
@@ -75,6 +87,9 @@ Zephyr shall provide file close capabilities for files on the file system.
 USER_STORY: >>>
 As a Zephyr OS user I want to be able to close a file after being finished with my file operations, unlocking any access restrictions.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-6
@@ -85,6 +100,9 @@ TITLE: Move file
 STATEMENT: >>>
 Zephyr shall provide the capability to move files on the file system.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6
 
 [REQUIREMENT]
 UID: ZEP-SRS-17-7
@@ -98,3 +116,6 @@ Zephyr shall provide file delete capabilities for files on the file system.
 USER_STORY: >>>
 As a Zephyr OS user I want to be able to delete an existing file.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-6

--- a/docs/software_requirements/logging.sdoc
+++ b/docs/software_requirements/logging.sdoc
@@ -22,6 +22,9 @@ The Zephyr RTOS shall support isolation of logging from other functionality.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to configure logging of events so the execution of logging activities does have no or only a minimal impact to the timing behaviour of my application.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8
 
 [REQUIREMENT]
 UID: ZEP-SRS-11-2
@@ -35,6 +38,9 @@ The Zephyr RTOS logging shall produce logs that are capable of being post proces
 USER_STORY: >>>
 As a Zephyr RTOS user I want the logging information to be stored in a format which allows to be read possibly converted or displayed by COTS tools.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8
 
 [REQUIREMENT]
 UID: ZEP-SRS-11-3
@@ -48,6 +54,9 @@ The Zephyr RTOS logging shall support formatting of log messages to enable filte
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able my application to format texts (printf alike) into the log message.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8
 
 [REQUIREMENT]
 UID: ZEP-SRS-11-4
@@ -61,6 +70,9 @@ The Zephyr RTOS logging system shall support filtering based on severity level.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to distinguish between different severity level for my log messages (e.g. DEBUG, INFO, WARN, ERROR, PANIC).
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8
 
 [REQUIREMENT]
 UID: ZEP-SRS-11-5
@@ -74,6 +86,9 @@ The Zephyr RTOS shall support logging messages to multiple system resources.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to simultaneously log to different channels which may store / redirect the information on / to different hardware (EEPROM, Flash, FRAM, UART, Ethernet, USB etc.).
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8
 
 [REQUIREMENT]
 UID: ZEP-SRS-11-6
@@ -87,3 +102,6 @@ The Zephyr RTOS shall support deferred logging (TODO: need more detail about the
 USER_STORY: >>>
 As a Zephyr RTOS user I want a minimal influence of logging activities to the timing behaviour of my application. Time consuming logging threads shall be done in the background.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-8

--- a/docs/software_requirements/memory_objects.sdoc
+++ b/docs/software_requirements/memory_objects.sdoc
@@ -22,6 +22,9 @@ The Zephyr RTOS shall allow threads to dynamically allocate variable-sized memor
 USER_STORY: >>>
 As a Zephyr RTOS user I want my application to be able to dynamically allocate memory of a application defined size.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-9-2
@@ -35,3 +38,6 @@ The Zephyr RTOS shall allow threads to dynamically allocate fixed-sized memory r
 USER_STORY: >>>
 As a Zephyr RTOS user I want a most efficient and least fragmentation prone dynamic memory allocation mechanism.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9

--- a/docs/software_requirements/memory_protection.sdoc
+++ b/docs/software_requirements/memory_protection.sdoc
@@ -22,6 +22,9 @@ The Zephyr RTOS shall support memory protection features to isolate a thread's m
 USER_STORY: >>>
 As a Zephyr RTOS user I want memory to be allocated and protected to my application threads preventing mistakenly access to foreign memory as far as the hardware allows.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-2
@@ -35,6 +38,9 @@ The Zephyr RTOS shall provide a mechanism to grant user threads access to kernel
 USER_STORY: >>>
 As a Zephyr RTOS user I want, from the user space, under certain conditions, access to kernel objects.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-3
@@ -48,6 +54,9 @@ The Zephyr RTOS shall be able to differentiate between user threads and kernel t
 USER_STORY: >>>
 As a Zephyr RTOS user I want, from the kernel space, unconditioned access to kernel objects.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-4
@@ -61,6 +70,9 @@ The Zephyr RTOS shall have a defined behaviour when an invocation of an unimplem
 USER_STORY: >>>
 As a Zephyr RTOS user I want Zephyr OS to indicate any unimplemented system call by an appropriate error message.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-5
@@ -74,6 +86,9 @@ The Zephyr RTOS shall have a defined behaviour when an invalid system call ID is
 USER_STORY: >>>
 As a Zephyr RTOS user I want Zephyr OS to indicate invalid system call by an appropriate error message.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-6
@@ -84,6 +99,9 @@ TITLE: Prevent user threads creating higher priority threads
 STATEMENT: >>>
 The Zephyr RTOS shall prevent user threads from creating new threads that are higher priority than the caller.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-7
@@ -97,6 +115,9 @@ The Zephyr RTOS shall support revoking permission to a kernel object. User mode 
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be protected against other user threads changing access to kernel objects of my thread.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-8
@@ -110,6 +131,9 @@ The Zephyr RTOS shall prevent user threads from creating kernel threads.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be protected against user threads creating higher privileged kernel/supervisor threads.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-9
@@ -123,6 +147,9 @@ The Zephyr RTOS shall allow the creation of threads that run in reduced privileg
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to create lower privileged threads than my own.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-10
@@ -136,6 +163,9 @@ The Zephyr RTOS shall provide system calls to allow user mode threads to perform
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to perform privileged operations in the kernel mode through a well defined interface.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-11
@@ -149,6 +179,9 @@ The Zephyr RTOS shall support a defined mechanism for user mode handling a of de
 USER_STORY: >>>
 As a Zephyr RTOS user I want, when a stack overflow is detected, to be able to implement a graceful, application defined handling of the exception.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-12
@@ -162,6 +195,9 @@ The Zephyr RTOS shall support detection of stack overflows.
 USER_STORY: >>>
 As a Zephyr RTOS user I want to get an indication when a stack overflow occurs at least during debugging / the development phase, and for safety applications also in a release version of my application.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-13
@@ -172,6 +208,9 @@ TITLE: Boot Time Memory Access Policy
 STATEMENT: >>>
 The Zephyr RTOS shall support configurable access to memory during boot time.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-14
@@ -185,6 +224,9 @@ The Zephyr RTOS shall provide helper functions for system call handler functions
 USER_STORY: >>>
 As a Zephyr RTOS user I want Zepyhr OS to validate system call parameters passed from the user mode to the kernel mode to avoid crashes and undefined behaviour.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-15
@@ -203,6 +245,9 @@ e.g.
 - verify the string length is smaller or equal to the syscalls defined max.
 - verify that the length type does not overflow when allocating one more byte ???
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-16
@@ -215,6 +260,9 @@ The Zephyr RTOS shall track kernel objects that are used by user mode threads.
 
 Note: this means Zephyr shall track the resources used by the user mode thread (associate this with a user story).
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-17
@@ -228,6 +276,9 @@ The Zephyr RTOS shall have an interface to request access to specific memory aft
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able to request read-only or read-write access to a dedicated memory area/pool during runtime.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9
 
 [REQUIREMENT]
 UID: ZEP-SRS-8-18
@@ -241,3 +292,6 @@ The Zephyr RTOS shall support assigning a memory pool to act as that thread's re
 USER_STORY: >>>
 As a Zephyr RTOS user I want to be able, during runtime from the kernel, to request a memory area/pool which is exclusively available to the requesting thread protected against access from other threads.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-9

--- a/docs/software_requirements/power_management.sdoc
+++ b/docs/software_requirements/power_management.sdoc
@@ -24,6 +24,9 @@ See ZEP104
 +
 When the power state is changed I want to get an notification in order for specific parts of my application to react accordingly.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
 
 [REQUIREMENT]
 UID: ZEP-SRS-13-2
@@ -34,6 +37,9 @@ TITLE: Power Management
 STATEMENT: >>>
 TBD
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
 
 [REQUIREMENT]
 UID: ZEP-SRS-13-3
@@ -44,3 +50,6 @@ TITLE: Notification of changes to system power states
 STATEMENT: >>>
 The Zephyr RTOS shall provide notification of changes to system power states.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10

--- a/docs/software_requirements/tracing.sdoc
+++ b/docs/software_requirements/tracing.sdoc
@@ -19,6 +19,9 @@ TITLE: Initializing a trace
 STATEMENT: >>>
 Zephyr shall provide an interface to initialize a trace.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19
 
 [REQUIREMENT]
 UID: ZEP-SRS-10-2
@@ -29,6 +32,9 @@ TITLE: Triggering a trace
 STATEMENT: >>>
 Zephyr shall provide an interface to trigger a trace.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19
 
 [REQUIREMENT]
 UID: ZEP-SRS-10-3
@@ -39,6 +45,9 @@ TITLE: Dumping trace results
 STATEMENT: >>>
 Zephyr shall provide an interface to dump results from a trace.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19
 
 [REQUIREMENT]
 UID: ZEP-SRS-10-4
@@ -49,6 +58,9 @@ TITLE: Removing trace data
 STATEMENT: >>>
 Zephyr shall provide an interface to remove trace data.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19
 
 [REQUIREMENT]
 UID: ZEP-SRS-10-5
@@ -62,6 +74,9 @@ Zephyr shall provide an interface to identify the objects being traced.
 USER_STORY: >>>
 As a Zepyhr OS user, I want to be able to give each object which I create a name / label in order to be able to identify them in a trace log.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19
 
 [REQUIREMENT]
 UID: ZEP-SRS-10-6
@@ -75,3 +90,6 @@ Zepyhr shall prevent the tracing functionality from interfering with normal oper
 USER_STORY: >>>
 As a Zepyhr OS user, I want that the trace functionality do not interfere or slow down the operation system functionality.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-19


### PR DESCRIPTION
Eight software requirement documents had requirements with no Parent
relation, breaking traceability to the system requirements. Add the
unambiguous parent link to every affected requirement:

- memory_objects, memory_protection -> ZEP-SYRS-9 (Memory Management)
- device_driver_api               -> ZEP-SYRS-4 (Device Drivers)
- exception_and_error_handling     -> ZEP-SYRS-5 (Exception and Error Handling)
- file_system                      -> ZEP-SYRS-6 (File Systems)
- logging                          -> ZEP-SYRS-8 (Logging)
- power_management                 -> ZEP-SYRS-10 (Power Management)
- tracing                          -> ZEP-SYRS-19 (Tracing)

Only Parent relations were added; no statements were changed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
