### PR TITLE
requirements: add missing parent link for semaphore maximum limit

### DIFF
--- a/docs/software_requirements/semaphore.sdoc
+++ b/docs/software_requirements/semaphore.sdoc
@@ -45,6 +45,9 @@ TITLE: Maximum limit of a semaphore
 STATEMENT: >>>
 The Zephyr RTOS shall define the maximum limit of a semaphore when the semaphore is used for counting purposes and does not have an explicit limit.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-14
 
 [REQUIREMENT]
 UID: ZEP-SRS-5-4


### PR DESCRIPTION
ZEP-SRS-5-3 (Maximum limit of a semaphore) was the only Semaphore
requirement without a Parent relation; link it to the Counting Semaphore
system requirement (ZEP-SYRS-14) for full traceability.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
