### PR TITLE
module: make reqmgmt appear as a west project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+
+* @nashif @parphane @tobiaskaestner @nicpappler

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+# nothing
+build: {}


### PR DESCRIPTION
This way we can pull this via the manifest and show this as a
dependency when building docs.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
