### PR TITLE
queues-requirements: Fix the parent relation values

### DIFF
--- a/docs/software_requirements/fifos.sdoc
+++ b/docs/software_requirements/fifos.sdoc
@@ -134,16 +134,3 @@ The Zephyr RTOS shall provide a mechanism to peek at the data item at the back o
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-24
-
-[REQUIREMENT]
-UID: ZEP-SRS-24-11
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Queues
-TITLE: Queue definition at compile time
-STATEMENT: >>>
-The Zephyr RTOS shall provide a mechanism to define and initialize a FIFO at compile time.
-<<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: ZEP-SYRS-22

--- a/docs/software_requirements/fifos.sdoc
+++ b/docs/software_requirements/fifos.sdoc
@@ -146,4 +146,4 @@ The Zephyr RTOS shall provide a mechanism to define and initialize a FIFO at com
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22

--- a/docs/software_requirements/queues.sdoc
+++ b/docs/software_requirements/queues.sdoc
@@ -16,7 +16,7 @@ The Zephyr RTOS shall provide a mechanism to define and initialize a queue at co
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-2
@@ -29,7 +29,7 @@ The Zephyr RTOS shall provide a mechanism to define and initialize a queue at ru
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-3
@@ -42,7 +42,7 @@ The Zephyr RTOS shall provide a mechanism to enqueue a data item to the back of 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-4
@@ -55,7 +55,7 @@ The Zephyr RTOS shall provide a mechanism to enqueue a data item to the front of
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-5
@@ -68,7 +68,7 @@ The Zephyr RTOS shall provide a mechanism to remove a specific data item from a 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-6
@@ -81,7 +81,7 @@ The Zephyr RTOS shall provide a mechanism to get and dequeue a data item from th
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-7
@@ -94,7 +94,7 @@ The Zephyr RTOS shall provide a mechanism to check if a queue is empty.
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-8
@@ -107,7 +107,7 @@ The Zephyr RTOS shall provide a mechanism to peek at the data data item at the b
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-9
@@ -120,7 +120,7 @@ The Zephyr RTOS shall provide a mechanism to peek at the data data item at the f
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-10
@@ -133,7 +133,7 @@ The Zephyr RTOS shall provide a mechanism to insert a data item behind another s
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-11
@@ -146,7 +146,7 @@ The Zephyr RTOS shall provide a mechanism to append a list of data items to the 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-12
@@ -159,7 +159,7 @@ The Zephyr RTOS shall provide a mechanism to append a list of data items to the 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-13
@@ -172,7 +172,7 @@ The Zephyr RTOS shall provide a mechanism to append a data item uniquely to the 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22
 
 [REQUIREMENT]
 UID: ZEP-SRS-20-14
@@ -186,4 +186,4 @@ data items to a queue.
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-21
+  VALUE: ZEP-SYRS-22


### PR DESCRIPTION
The parent relation values were pointing to the top requirement about condition variables instead of the one for the queues.

This addresses the issue https://github.com/zephyrproject-rtos/reqmgmt/issues/138.