### PR TITLE
stacks: align sys requirement IDs for consistency

### DIFF
--- a/docs/software_requirements/stacks.sdoc
+++ b/docs/software_requirements/stacks.sdoc
@@ -21,7 +21,7 @@ The Zephyr RTOS shall provide a mechanism to define and initialize a stack at co
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-2
@@ -34,7 +34,7 @@ The Zephyr RTOS shall provide a mechanism to initialize a stack at run time, usi
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-3
@@ -47,7 +47,7 @@ The Zephyr RTOS shall provide a mechanism to initialize a stack at run time, wit
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-4
@@ -60,7 +60,7 @@ The Zephyr RTOS shall provide a mechanism to deallocate all resources previously
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-5
@@ -73,7 +73,7 @@ The Zephyr RTOS shall provide a mechanism to add a new item on top of the stack.
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 - TYPE: Parent
   VALUE: ZEP-SRS-30-7
 
@@ -88,7 +88,7 @@ The Zephyr RTOS shall provide a mechanism to retrieve the current item from the 
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 - TYPE: Parent
   VALUE: ZEP-SRS-30-9
 
@@ -103,7 +103,7 @@ If the stack is full when an item is pushed, the Zephyr RTOS shall return an err
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-8
@@ -119,7 +119,7 @@ As a Zephyr RTOS user I want to access a stack from different execution contexts
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30
 
 [REQUIREMENT]
 UID: ZEP-SRS-30-9
@@ -135,4 +135,4 @@ As a Zephyr RTOS user I want to share a stack object between a producer and a co
 <<<
 RELATIONS:
 - TYPE: Parent
-  VALUE: ZEP-SYRS-26
+  VALUE: ZEP-SYRS-30

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -373,7 +373,7 @@ The Zephyr RTOS shall provide a framework to pass messages of arbitrary size bet
 TITLE: Stacks
 
 [REQUIREMENT]
-UID: ZEP-SYRS-26
+UID: ZEP-SYRS-30
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Stacks


### PR DESCRIPTION
Use ZEP-SYRS-30 instead of ZEP-SYRS-26 for consistency.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
