### PR TITLE
requirements: add Events system and software requirements

### DIFF
--- a/docs/software_requirements/events.sdoc
+++ b/docs/software_requirements/events.sdoc
@@ -1,0 +1,221 @@
+[DOCUMENT]
+TITLE: Events
+REQ_PREFIX: ZEP-SRS-27-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[TEXT]
+STATEMENT: >>>
+SPDX-License-Identifier: Apache-2.0
+<<<
+
+[[SECTION]]
+TITLE: Event Object Definition
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-1
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Event object definition at compile time
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to define and initialize an event object at compile time.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-2
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Event object definition at run time
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to initialize an event object at run time.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-3
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Number of distinct events
+STATEMENT: >>>
+The Zephyr RTOS shall provide an event object capable of tracking up to 32 distinct events.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Delivering Events
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-4
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Posting events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to post one or more events to an event object, merging them with the events currently tracked by the event object.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Setting events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to set the events tracked by an event object to a specified value, replacing the events currently tracked by the event object.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Setting and clearing events using a mask
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to set the events selected by a mask to specified values, leaving the events tracked by the event object that are not selected by the mask unchanged.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Clearing events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to clear specified events tracked by an event object.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Reporting the previous events
+STATEMENT: >>>
+When the events tracked by an event object are modified, the Zephyr RTOS shall report the value that the modified events had before the operation.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-9
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Unpending threads whose conditions are met
+STATEMENT: >>>
+When a modification of the events tracked by an event object satisfies the waiting condition of a thread waiting on that event object, the Zephyr RTOS shall unpend that thread.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Waiting for Events
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Waiting for any of a set of events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism for a thread to wait until any of a specified set of events is tracked by an event object.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-11
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Waiting for all of a set of events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism for a thread to wait until all of a specified set of events are tracked by an event object.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-12
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Event wait timeout
+STATEMENT: >>>
+When a thread waits on an event object, the Zephyr RTOS shall accept a timeout that specifies the maximum time to wait for the desired set of events.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-13
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Event wait timeout expiry
+STATEMENT: >>>
+When the timeout of a thread waiting on an event object elapses before the desired set of events is satisfied, the Zephyr RTOS shall report that no matching events were delivered.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-14
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Reporting matching events on wait completion
+STATEMENT: >>>
+When a thread waiting on an event object completes its wait successfully, the Zephyr RTOS shall report the set of events that matched the waiting condition.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[REQUIREMENT]
+UID: ZEP-SRS-27-15
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Resetting events before waiting
+STATEMENT: >>>
+When a thread waits on an event object, the Zephyr RTOS shall accept an option to clear the events tracked by the event object before the wait begins.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-27
+
+[[/SECTION]]

--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -23,6 +23,9 @@ FILE: condition_variables.sdoc
 FILE: device_driver_api.sdoc
 
 [DOCUMENT_FROM_FILE]
+FILE: events.sdoc
+
+[DOCUMENT_FROM_FILE]
 FILE: exception_and_error_handling.sdoc
 
 [DOCUMENT_FROM_FILE]

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -80,6 +80,24 @@ As a Zephyr RTOS user I want errors and exceptions to handled and react accordin
 <<<
 
 [[SECTION]]
+TITLE: Events
+
+[REQUIREMENT]
+UID: ZEP-SYRS-27
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Events
+TITLE: Events
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to synchronize threads based on a set of events.
+<<<
+USER_STORY: >>>
+As a Zephyr RTOS user I want a thread to wait until one or more application-defined events have occurred so that it can coordinate its execution with other threads and ISRs.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 TITLE: FIFOs
 
 [REQUIREMENT]


### PR DESCRIPTION
Add a System requirement (ZEP-SYRS-27) describing the Zephyr event
object synchronization mechanism, and a new Events software requirements
document (ZEP-SRS-27-*) refining it into 15 atomic, implementation-free
requirements covering event object definition, delivering events
(post/set/set-masked/clear), and waiting for events (any/all, timeout,
reset, reported results).

The requirements reflect the currently implemented k_event API behavior
following the Route 3s approach. All software requirements link to the
ZEP-SYRS-27 system parent, and the new document is registered in the
software requirements index. UIDs were generated with
"strictdoc manage auto-uid".

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
