### PR TITLE
requirements: expand and review Hardware Architecture Interface

### DIFF
--- a/docs/software_requirements/hw_arch_interface.sdoc
+++ b/docs/software_requirements/hw_arch_interface.sdoc
@@ -65,12 +65,125 @@ TYPE: Functional
 COMPONENT: Hardware Architecture Interface
 TITLE: Processor Mode Support
 STATEMENT: >>>
-The Zephyr RTOS shall provide an interface for managing processor modes.
+The Zephyr RTOS shall provide an interface for managing processor execution modes.
 <<<
 USER_STORY: >>>
-If MCU power state was meant here:
-As a Zephyr RTOS user I want to control the MCU's power saving mode such e.g. operation, sleep, deep sleep or similar as supported by the selected MCU.
+As a Zephyr RTOS user I want the kernel to execute code at the appropriate processor privilege level (for example supervisor and user mode) so that privileged and unprivileged execution are kept separate.
 <<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-1
+
+[[SECTION]]
+TITLE: Cache Management
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Data cache maintenance
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to perform data cache maintenance operations, including flush, invalidate, and combined flush-and-invalidate, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Instruction cache maintenance
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to perform instruction cache maintenance operations, including flush, invalidate, and combined flush-and-invalidate, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Cache activation control
+STATEMENT: >>>
+Where a cache is present, the Zephyr RTOS shall provide an interface to enable and disable the data cache and the instruction cache.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Cache line size query
+STATEMENT: >>>
+Where a cache is present, the Zephyr RTOS shall provide an interface to obtain the cache line size.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-9
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Memory coherence reporting
+STATEMENT: >>>
+Where the architecture can determine memory coherence, the Zephyr RTOS shall provide an interface to report whether a memory region is coherent with respect to the data cache.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Diagnostics and Debug
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Call stack unwinding
+STATEMENT: >>>
+Where stack unwinding is supported, the Zephyr RTOS shall provide an interface to walk the call stack of a thread and report each stack frame to a caller-supplied function.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-11
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Core dump processor state capture
+STATEMENT: >>>
+Where core dump support is enabled, the Zephyr RTOS shall provide an interface to capture architecture-specific processor state for inclusion in a core dump.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-12
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: External debugger interface
+STATEMENT: >>>
+Where a debug stub is enabled, the Zephyr RTOS shall provide an architecture interface that allows an external debugger to read and write processor registers, manage breakpoints, and single-step execution.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[[/SECTION]]

--- a/docs/software_requirements/hw_arch_interface.sdoc
+++ b/docs/software_requirements/hw_arch_interface.sdoc
@@ -63,14 +63,231 @@ UID: ZEP-SRS-19-4
 STATUS: Draft
 TYPE: Functional
 COMPONENT: Hardware Architecture Interface
-TITLE: Processor Mode Support
+TITLE: Entering user mode
 STATEMENT: >>>
-The Zephyr RTOS shall provide an interface for managing processor modes.
+Where user mode is supported, the Zephyr RTOS shall provide an interface to transition the executing thread from supervisor mode to user mode.
 <<<
 USER_STORY: >>>
-If MCU power state was meant here:
-As a Zephyr RTOS user I want to control the MCU's power saving mode such e.g. operation, sleep, deep sleep or similar as supported by the selected MCU.
+As a Zephyr RTOS user I want the kernel to execute code at the appropriate processor privilege level (for example supervisor and user mode) so that privileged and unprivileged execution are kept separate.
 <<<
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-1
+
+[[SECTION]]
+TITLE: Cache Management
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-13
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Execution mode query
+STATEMENT: >>>
+Where user mode is supported, the Zephyr RTOS shall provide an interface to query whether the current execution context is running in user mode.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-14
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: System call invocation
+STATEMENT: >>>
+Where user mode is supported, the Zephyr RTOS shall provide an interface for user mode code to invoke system calls that execute in supervisor mode.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Data cache flush
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to flush the data cache, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-15
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Data cache invalidation
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to invalidate the data cache, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-16
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Combined data cache flush and invalidation
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to flush and invalidate the data cache in a single operation, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Instruction cache flush
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to flush the instruction cache, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-17
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Instruction cache invalidation
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to invalidate the instruction cache, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-18
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Combined instruction cache flush and invalidation
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to flush and invalidate the instruction cache in a single operation, over the entire cache or a specified address range.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Data cache activation control
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to enable and disable the data cache.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-19
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Instruction cache activation control
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to enable and disable the instruction cache.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Data cache line size query
+STATEMENT: >>>
+Where a data cache is present, the Zephyr RTOS shall provide an interface to obtain the data cache line size.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-20
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Instruction cache line size query
+STATEMENT: >>>
+Where an instruction cache is present, the Zephyr RTOS shall provide an interface to obtain the instruction cache line size.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-9
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Memory coherence reporting
+STATEMENT: >>>
+Where the architecture can determine memory coherence, the Zephyr RTOS shall provide an interface to report whether a memory region is coherent with respect to the data cache.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Diagnostics and Debug
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Call stack unwinding
+STATEMENT: >>>
+Where stack unwinding is supported, the Zephyr RTOS shall provide an interface to walk the call stack of a thread and report each stack frame to a caller-supplied function.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-11
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: Core dump processor state capture
+STATEMENT: >>>
+Where core dump support is enabled, the Zephyr RTOS shall provide an interface to capture architecture-specific processor state for inclusion in a core dump.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[REQUIREMENT]
+UID: ZEP-SRS-19-12
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Hardware Architecture Interface
+TITLE: External debugger interface
+STATEMENT: >>>
+Where a debug stub is enabled, the Zephyr RTOS shall provide an architecture interface that allows an external debugger to read and write processor registers, manage breakpoints, and single-step execution.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-1
+
+[[/SECTION]]


### PR DESCRIPTION
Audit of the architecture porting interface (include/zephyr/arch,
arch_interface.h) against the existing component (only ZEP-SRS-19-1..4)
surfaced two capability areas with no requirement coverage in any
component. Add eight requirements (Route 3), all parented to ZEP-SYRS-1.

Cache Management (no prior coverage anywhere):
- ZEP-SRS-19-5  Data cache maintenance
- ZEP-SRS-19-6  Instruction cache maintenance
- ZEP-SRS-19-7  Cache activation control
- ZEP-SRS-19-8  Cache line size query
- ZEP-SRS-19-9  Memory coherence reporting

Diagnostics and Debug:
- ZEP-SRS-19-10 Call stack unwinding
- ZEP-SRS-19-11 Core dump processor state capture
- ZEP-SRS-19-12 External debugger interface

Also reword ZEP-SRS-19-2 to "processor execution modes" and replace
its user story, which described MCU power saving modes (a Power
Management concern) and still carried a review note questioning that.

Interrupt management, fatal/exception handling, CPU idle/power, cycle
counter/busy-wait, FPU context, virtual memory mapping, user mode and
SMP arch primitives were intentionally NOT duplicated here: they are
already owned by the interrupts, exception_and_error_handling,
power_management, kernel_timing, floating_point, memory_protection,
virtual_memory and smp components respectively.

UIDs were generated with "strictdoc manage auto-uid".

Assisted-by: Claude:claude-fable-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
