### PR TITLE
requirements: expand Exception and Error Handling requirements

### DIFF
--- a/docs/software_requirements/exception_and_error_handling.sdoc
+++ b/docs/software_requirements/exception_and_error_handling.sdoc
@@ -64,3 +64,55 @@ The Zephyr RTOS shall provide an interface to assign a specific handler for a fa
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-5
+
+[REQUIREMENT]
+UID: ZEP-SRS-16-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Exception and Error Handling
+TITLE: Triggering a fatal error in the current context
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism for code to trigger a fatal error that terminates the currently running context.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
+
+[REQUIREMENT]
+UID: ZEP-SRS-16-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Exception and Error Handling
+TITLE: Triggering a fatal system error
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism for code to trigger a fatal error that terminates the system.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
+
+[REQUIREMENT]
+UID: ZEP-SRS-16-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Exception and Error Handling
+TITLE: Fatal error reason
+STATEMENT: >>>
+When a fatal error handler is invoked, the Zephyr RTOS shall provide a reason code identifying the type of error.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5
+
+[REQUIREMENT]
+UID: ZEP-SRS-16-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Exception and Error Handling
+TITLE: Default fatal error policy
+STATEMENT: >>>
+When a fatal error occurs and the application does not provide a different policy, the Zephyr RTOS shall terminate the offending thread if the error occurred in a thread context, and otherwise halt the system.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-5


### PR DESCRIPTION
The document covered default and assignable handlers but not triggering
fatal errors or the handler contract. Add four requirements
(ZEP-SRS-16-5 .. ZEP-SRS-16-8): triggering a fatal error that terminates
the current context (kernel oops), triggering a fatal error that
terminates the system (kernel panic), providing a reason code to the
fatal error handler, and the default fatal error policy (terminate the
offending thread in thread context, otherwise halt the system).

The requirements reflect the implemented k_oops, k_panic, k_fatal_halt,
and k_sys_fatal_error_handler behavior following the Route 3s approach
and link to the system parent (ZEP-SYRS-5). UIDs were generated with
"strictdoc manage auto-uid".

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
