### PR TITLE
requirements: add mutex waiter handoff and condvar mutex re-acquire

### DIFF
--- a/docs/software_requirements/condition_variables.sdoc
+++ b/docs/software_requirements/condition_variables.sdoc
@@ -121,3 +121,16 @@ Whenever a thread signals a condition variable, the Zephyr RTOS shall unblock th
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-21
+
+[REQUIREMENT]
+UID: ZEP-SRS-21-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Condition Variables
+TITLE: Re-acquiring the mutex on return from wait
+STATEMENT: >>>
+When a wait on a condition variable returns, whether due to a signal, a timeout, or a non-blocking request, the Zephyr RTOS shall return with the associated mutex locked by the calling thread.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-21

--- a/docs/software_requirements/mutex.sdoc
+++ b/docs/software_requirements/mutex.sdoc
@@ -171,3 +171,16 @@ While a higher-priority thread is blocked waiting on a mutex, the Zephyr RTOS sh
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-13
+
+[REQUIREMENT]
+UID: ZEP-SRS-6-13
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Mutex
+TITLE: Highest-priority waiter acquires a released mutex
+STATEMENT: >>>
+When a mutex is unlocked while one or more threads are waiting to lock it, the Zephyr RTOS shall grant ownership of the mutex to the highest-priority waiting thread.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-13


### PR DESCRIPTION
Sweep of tests/kernel/{mutex,semaphore,condvar} found two implemented,
tested behaviors with no requirement:

- ZEP-SRS-6-13 Highest-priority waiter acquires a released mutex (mutex
  analogue of the semaphore's 5-14; verified by sys_mutex
  test_mutex_multithread_competition and mutex_api test_complex_inversion).
- ZEP-SRS-21-10 Re-acquiring the mutex on return from wait (the
  complement of 21-8 'release mutex on wait'; verified by
  test_condvar_wait_timeout_relocks_mutex, test_condvar_wait_nowait_keeps_mutex,
  test_condvar_wait_signaled_keeps_mutex).

Parented to ZEP-SYRS-13 (mutex) and ZEP-SYRS-21 (condvar) respectively.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
