### PR TITLE
requirements: add queue cancel waiting thread

### DIFF
--- a/docs/software_requirements/queues.sdoc
+++ b/docs/software_requirements/queues.sdoc
@@ -187,3 +187,16 @@ data items to a queue.
 RELATIONS:
 - TYPE: Parent
   VALUE: ZEP-SYRS-22
+
+[REQUIREMENT]
+UID: ZEP-SRS-20-15
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Queues
+TITLE: Queue cancel waiting thread
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to cause a thread that is blocked waiting to get an item from a queue to return without an item.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-22


### PR DESCRIPTION
Sweep of tests/kernel/queue found k_queue_cancel_wait coverage
(test_queue_cancel_wait_error, test_queue_supv_to_user) with no
requirement; queues lacked the equivalent of the FIFO's ZEP-SRS-24-2.
Add ZEP-SRS-20-15 'Queue cancel waiting thread' (parent ZEP-SYRS-22).

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
