### PR TITLE
requirements: add Futex component

### DIFF
--- a/docs/software_requirements/futex.sdoc
+++ b/docs/software_requirements/futex.sdoc
@@ -1,0 +1,50 @@
+[DOCUMENT]
+TITLE: Futex
+REQ_PREFIX: ZEP-SRS-37-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: software_requirements.sgra
+
+[TEXT]
+STATEMENT: >>>
+SPDX-License-Identifier: Apache-2.0
+<<<
+
+[REQUIREMENT]
+UID: ZEP-SRS-37-1
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Futex
+TITLE: Pending on a futex
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism for a thread to atomically test a futex against an expected value and, if they match, block until the futex is woken or a specified timeout elapses.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-36
+
+[REQUIREMENT]
+UID: ZEP-SRS-37-2
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Futex
+TITLE: Waking threads pending on a futex
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to wake either the highest-priority thread or all threads pending on a futex.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-36
+
+[REQUIREMENT]
+UID: ZEP-SRS-37-3
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Futex
+TITLE: Futex operation from user mode
+STATEMENT: >>>
+The Zephyr RTOS shall allow user mode threads to operate on a futex located in memory they can access, and shall reject futex operations on memory the calling thread cannot access.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-36

--- a/docs/software_requirements/index.sdoc
+++ b/docs/software_requirements/index.sdoc
@@ -35,6 +35,9 @@ FILE: fifos.sdoc
 FILE: file_system.sdoc
 
 [DOCUMENT_FROM_FILE]
+FILE: futex.sdoc
+
+[DOCUMENT_FROM_FILE]
 FILE: hw_arch_interface.sdoc
 
 [DOCUMENT_FROM_FILE]

--- a/docs/system_requirements/index.sdoc
+++ b/docs/system_requirements/index.sdoc
@@ -190,6 +190,24 @@ RELATIONS:
   VALUE: ZEP-SYRS-7
 
 [[SECTION]]
+TITLE: Futex
+
+[REQUIREMENT]
+UID: ZEP-SYRS-36
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Futex
+TITLE: Futex
+STATEMENT: >>>
+The Zephyr RTOS shall provide a low-overhead synchronization primitive that user mode threads can operate on directly.
+<<<
+USER_STORY: >>>
+As a Zephyr RTOS user, I want a fast user-space synchronization primitive that does not require a system call in the uncontended case.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 TITLE: Kernel Timing
 
 [REQUIREMENT]


### PR DESCRIPTION
The futex fast user-space synchronization primitive (k_futex_wait/
k_futex_wake), exercised by tests/kernel/mem_protect/futex, had no
requirement. Add system requirement ZEP-SYRS-36 (Futex) and a new
Futex software component (ZEP-SRS-37-1..37-3): pending on a futex,
waking pending threads, and user-mode futex operation/access control.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
