### PR TITLE
requirements: clean up and expand Device Driver API requirements

### DIFF
--- a/docs/software_requirements/device_driver_api.sdoc
+++ b/docs/software_requirements/device_driver_api.sdoc
@@ -17,9 +17,7 @@ TYPE: Functional
 COMPONENT: Device Driver API
 TITLE: Device Driver Abstraction
 STATEMENT: >>>
-The Zephyr RTOS shall provide abstraction of device drivers with common functionalities as an intermediate interface between applications and device drivers, where such interface is implemented by individual device drivers.
-
-Proposal for replacement: Zephyr shall provide an interface between application and individual device drivers to provide an abstraction of device drivers with common functionalities.
+The Zephyr RTOS shall provide an interface between applications and individual device drivers that abstracts common device driver functionality.
 <<<
 RELATIONS:
 - TYPE: Parent
@@ -36,6 +34,136 @@ The Zephyr RTOS shall provide an interface for managing a defined set of hardwar
 <<<
 USER_STORY: >>>
 As a Zephyr RTOS user I want hardware exceptions (hardware failures, programming mistakes) to be handled gracefully (no program crashes as far as possible).
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-3
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Defining a device instance
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to define a device instance together with its initialization function and its driver API.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-4
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Obtaining a device by name
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to obtain a reference to a device instance by its name.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Obtaining a device from a devicetree node
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to obtain a reference to a device instance from its devicetree node.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Checking device readiness
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to determine whether a device instance is ready to be used.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Deferred device initialization
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to defer a device's initialization so that it is not initialized during system startup but can be initialized later at runtime.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Reporting deferred initialization failure
+STATEMENT: >>>
+If a deferred device initialization fails, then the Zephyr RTOS shall report the failure and leave the device in a not-ready state.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-9
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: De-initializing a device
+STATEMENT: >>>
+Where device de-initialization is enabled, the Zephyr RTOS shall provide a mechanism to de-initialize a device at runtime.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Rejecting de-initialization of an unsupported device
+STATEMENT: >>>
+If de-initialization is requested for a device that does not provide a de-initialization function, then the Zephyr RTOS shall report that the operation is not supported.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-11
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Querying device dependency relationships
+STATEMENT: >>>
+Where device dependencies are stored, the Zephyr RTOS shall provide a mechanism to query the set of devices that a device depends on and the set of devices that depend on it.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-4
+
+[REQUIREMENT]
+UID: ZEP-SRS-14-12
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Device Driver API
+TITLE: Obtaining a device by devicetree node label
+STATEMENT: >>>
+Where devicetree device metadata is stored, the Zephyr RTOS shall provide a mechanism to obtain a reference to a device instance by its devicetree node label.
 <<<
 RELATIONS:
 - TYPE: Parent


### PR DESCRIPTION
Remove the embedded "Proposal for replacement" note from the Device
Driver Abstraction requirement (ZEP-SRS-14-1) and adopt the cleaner
wording. Add ten requirements (ZEP-SRS-14-3 .. ZEP-SRS-14-12) for the
device model:

- ZEP-SRS-14-3  Defining a device instance with its init function and API
- ZEP-SRS-14-4  Obtaining a device reference by name
- ZEP-SRS-14-5  Obtaining a device reference from a devicetree node
- ZEP-SRS-14-6  Checking device readiness
- ZEP-SRS-14-7  Deferred device initialization
- ZEP-SRS-14-8  Reporting deferred initialization failure
- ZEP-SRS-14-9  De-initializing a device (CONFIG_DEVICE_DEINIT_SUPPORT)
- ZEP-SRS-14-10 Rejecting de-initialization of an unsupported device
- ZEP-SRS-14-11 Querying device dependency relationships (CONFIG_DEVICE_DEPS)
- ZEP-SRS-14-12 Obtaining a device by devicetree node label
                (CONFIG_DEVICE_DT_METADATA)

The requirements reflect the implemented device model behavior
(DEVICE_DEFINE, device_get_binding, DEVICE_DT_GET, device_is_ready,
device_deinit) following the Route 3s approach and link to the Device
Drivers system parent (ZEP-SYRS-4). UIDs were generated with
"strictdoc manage auto-uid".

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
