### PR TITLE
requirements: clean up and expand Power Management requirements

### DIFF
--- a/docs/software_requirements/power_management.sdoc
+++ b/docs/software_requirements/power_management.sdoc
@@ -20,22 +20,7 @@ STATEMENT: >>>
 The Zephyr RTOS shall provide control over changes to system power states.
 <<<
 USER_STORY: >>>
-See ZEP104
-+
-When the power state is changed I want to get an notification in order for specific parts of my application to react accordingly.
-<<<
-RELATIONS:
-- TYPE: Parent
-  VALUE: ZEP-SYRS-10
-
-[REQUIREMENT]
-UID: ZEP-SRS-13-2
-STATUS: Draft
-TYPE: Functional
-COMPONENT: Power Management
-TITLE: Power Management
-STATEMENT: >>>
-TBD
+When the power state is changed I want to get a notification so that specific parts of my application can react accordingly.
 <<<
 RELATIONS:
 - TYPE: Parent
@@ -49,6 +34,149 @@ COMPONENT: Power Management
 TITLE: Notification of changes to system power states
 STATEMENT: >>>
 The Zephyr RTOS shall provide notification of changes to system power states.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-4
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Multiple system power states
+STATEMENT: >>>
+The Zephyr RTOS shall support multiple system power states that differ in power consumption and wake-up latency.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-5
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Entering a low-power state when idle
+STATEMENT: >>>
+When all CPUs become idle, the Zephyr RTOS shall place the system into a low-power state selected by the power management policy.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-6
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Power state selection by anticipated idle time
+STATEMENT: >>>
+The Zephyr RTOS shall select the system power state based on the time remaining until the next scheduled kernel event.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-7
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Forcing a power state
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to override the power management policy and force the system into a specified power state.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-8
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Preventing entry into a power state
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to prevent the system from entering a specified power state.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-9
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Wake-up latency constraint
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to impose a maximum wake-up latency constraint that the power management policy shall respect when selecting a power state.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-10
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Device power states
+STATEMENT: >>>
+The Zephyr RTOS shall support device power states, including active, suspended, and off.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-11
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Device power state transitions
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to request a device to transition between its power states.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-12
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Runtime device power management
+STATEMENT: >>>
+The Zephyr RTOS shall provide runtime device power management that resumes a device when it is requested for use and suspends it when it is no longer in use.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-13
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Querying device power state
+STATEMENT: >>>
+The Zephyr RTOS shall provide a mechanism to query the current power state of a device.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: ZEP-SYRS-10
+
+[REQUIREMENT]
+UID: ZEP-SRS-13-14
+STATUS: Draft
+TYPE: Functional
+COMPONENT: Power Management
+TITLE: Idling the current CPU
+STATEMENT: >>>
+The Zephyr RTOS shall provide an interface for the calling thread to place the current CPU into a low-power idle state until an interrupt occurs, including a variant that atomically re-enables interrupts as the CPU enters the idle state.
 <<<
 RELATIONS:
 - TYPE: Parent


### PR DESCRIPTION
ZEP-SRS-13-2 was a placeholder requirement whose statement was literally
"TBD" and whose title duplicated the component name; remove it. Nothing
referenced it. Also clean the ZEP-SRS-13-1 user story, dropping the
imported "See ZEP104"/"+" artifacts and fixing "an notification" ->
"a notification".

The document then covered only control and notification. Add eleven
requirements (ZEP-SRS-13-4 .. ZEP-SRS-13-14) covering system and device
power management:

- multiple system power states differing in consumption and latency
- entering a low-power state when all CPUs are idle
- power state selection based on anticipated idle time (policy)
- forcing a power state and preventing entry into a power state
- wake-up latency constraints honored by the policy
- device power states (active, suspended, off)
- device power state transitions
- runtime device power management (resume on use, suspend when unused)
- querying a device's current power state
- idling the current CPU until an interrupt occurs

The requirements reflect the implemented system PM (pm_state_force,
pm_policy_*), device PM (pm_device_action_run, pm_device_runtime_*,
pm_device_state_get) and CPU idle (k_cpu_idle, k_cpu_atomic_idle)
behavior following the Route 3s approach and link to the Power
Management system parent (ZEP-SYRS-10). UIDs were generated with
"strictdoc manage auto-uid".

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
